### PR TITLE
Economic improvements: gathering fixes, building UI, and balance

### DIFF
--- a/Grow2 Shared/Commands/BuildCommand.swift
+++ b/Grow2 Shared/Commands/BuildCommand.swift
@@ -221,6 +221,6 @@ struct BuildCommand: GameCommand {
         let hasAnyMountainTile = coordinates.contains { coord in
             hexMap.getTile(at: coord)?.terrain == .mountain
         }
-        return hasAnyMountainTile ? 1.25 : 1.0
+        return hasAnyMountainTile ? GameConfig.Terrain.mountainBuildingCostMultiplier : 1.0
     }
 }

--- a/Grow2 Shared/Commands/BuildCommand.swift
+++ b/Grow2 Shared/Commands/BuildCommand.swift
@@ -124,12 +124,14 @@ struct BuildCommand: GameCommand {
 
         // Check if builder is already at the location
         var builderAtLocation = false
+        var villagerCount = 1
 
         // Assign builder if provided
         if let builderID = builderEntityID,
            let builderEntity = context.getEntity(by: builderID),
            let villagers = builderEntity.entity as? VillagerGroup {
             building.builderEntity = builderEntity
+            villagerCount = villagers.villagerCount
             villagers.assignTask(.building(building), target: coordinate)
 
             // Check if villager is already at the build site (must be ON the tile, not adjacent)
@@ -142,12 +144,13 @@ struct BuildCommand: GameCommand {
                 builderEntity.isMoving = true
 
                 // Move the entity to the build site
+                let builderCount = villagerCount
                 if let path = context.hexMap.findPath(from: builderEntity.coordinate, to: coordinate, for: builderEntity.entity.owner) {
                     builderEntity.moveTo(path: path) {
                         // When movement completes, start construction
                         if building.state == .planning {
-                            building.startConstruction()
-                            debugLog("🏗️ Builder arrived, starting construction of \(building.buildingType.displayName)")
+                            building.startConstruction(builders: builderCount)
+                            debugLog("🏗️ Builder arrived (\(builderCount) villagers), starting construction of \(building.buildingType.displayName)")
                         }
                     }
                 } else {
@@ -162,7 +165,7 @@ struct BuildCommand: GameCommand {
 
         // Only start construction if builder is at location or no builder needed
         if builderAtLocation {
-            building.startConstruction()
+            building.startConstruction(builders: villagerCount)
         } else {
             // Set to planning state - construction will start when builder arrives
             building.data.state = .planning

--- a/Grow2 Shared/Commands/EngineCommands.swift
+++ b/Grow2 Shared/Commands/EngineCommands.swift
@@ -485,7 +485,15 @@ struct EngineDeployArmyCommand: EngineCompatibleCommand {
 
         // Create army
         let army = ArmyData(name: "Army", coordinate: spawnCoord, ownerID: playerID)
-        army.homeBaseID = buildingID
+
+        // Assign home base respecting capacity limits
+        if state.hasHomeBaseCapacity(buildingID: buildingID) {
+            army.homeBaseID = buildingID
+        } else if let fallback = state.findHomeBaseWithCapacity(for: playerID, from: spawnCoord, excluding: nil) {
+            army.homeBaseID = fallback.id
+        } else {
+            army.homeBaseID = buildingID
+        }
 
         // Add units
         for (unitType, count) in composition {

--- a/Grow2 Shared/Commands/TrainCommand.swift
+++ b/Grow2 Shared/Commands/TrainCommand.swift
@@ -44,10 +44,11 @@ struct TrainMilitaryCommand: GameCommand {
             return .failure(reason: "This building cannot train \(unitType.displayName)")
         }
         
-        // Check population cap
-        guard player.hasPopulationSpace(for: quantity) else {
+        // Check population cap (siege units cost more pop space)
+        let popNeeded = unitType.popSpace * quantity
+        guard player.hasPopulationSpace(for: popNeeded) else {
             let available = player.getAvailablePopulation()
-            return .failure(reason: "Population cap reached. Available: \(available)")
+            return .failure(reason: "Population cap reached. Need \(popNeeded) pop, available: \(available)")
         }
         
         // Get adjacency cost reduction (warehouse bonus)

--- a/Grow2 Shared/Data/ArmyData.swift
+++ b/Grow2 Shared/Data/ArmyData.swift
@@ -208,6 +208,15 @@ enum MilitaryUnitTypeData: String, Codable, CaseIterable {
         case .mangonel, .trebuchet: return .siegeWorkshop
         }
     }
+
+    /// Population space consumed by this unit type
+    var popSpace: Int {
+        switch self {
+        case .mangonel: return 3
+        case .trebuchet: return 5
+        default: return 1
+        }
+    }
 }
 
 // MARK: - Unit Category Data
@@ -435,6 +444,11 @@ class ArmyData: Codable {
 
     func getTotalUnits() -> Int {
         return militaryComposition.values.reduce(0, +)
+    }
+
+    /// Returns total population space used by this army (siege units cost more)
+    func getPopulationUsed() -> Int {
+        return militaryComposition.reduce(0) { $0 + $1.key.popSpace * $1.value }
     }
 
     func getUnitCount(ofType type: MilitaryUnitTypeData) -> Int {

--- a/Grow2 Shared/Data/BuildingData.swift
+++ b/Grow2 Shared/Data/BuildingData.swift
@@ -27,6 +27,8 @@ class BuildingData: Codable {
     var constructionProgress: Double = 0.0
     var constructionStartTime: TimeInterval?
     var buildersAssigned: Int = 0
+    var constructionHP: Double = 0.0
+    var lastConstructionUpdateTime: TimeInterval?
     
     // MARK: - Upgrade
     var upgradeProgress: Double = 0.0
@@ -102,6 +104,7 @@ class BuildingData: Codable {
         case id, buildingType, coordinate, ownerID, rotation
         case state, level, health, maxHealth
         case constructionProgress, constructionStartTime, buildersAssigned
+        case constructionHP, lastConstructionUpdateTime
         case upgradeProgress, upgradeStartTime
         case demolitionProgress, demolitionStartTime, demolishersAssigned
         case garrison, villagerGarrison
@@ -125,6 +128,8 @@ class BuildingData: Codable {
         constructionProgress = try container.decode(Double.self, forKey: .constructionProgress)
         constructionStartTime = try container.decodeIfPresent(TimeInterval.self, forKey: .constructionStartTime)
         buildersAssigned = try container.decode(Int.self, forKey: .buildersAssigned)
+        constructionHP = try container.decodeIfPresent(Double.self, forKey: .constructionHP) ?? 0.0
+        lastConstructionUpdateTime = try container.decodeIfPresent(TimeInterval.self, forKey: .lastConstructionUpdateTime)
         
         upgradeProgress = try container.decode(Double.self, forKey: .upgradeProgress)
         upgradeStartTime = try container.decodeIfPresent(TimeInterval.self, forKey: .upgradeStartTime)
@@ -157,6 +162,8 @@ class BuildingData: Codable {
         try container.encode(constructionProgress, forKey: .constructionProgress)
         try container.encodeIfPresent(constructionStartTime, forKey: .constructionStartTime)
         try container.encode(buildersAssigned, forKey: .buildersAssigned)
+        try container.encode(constructionHP, forKey: .constructionHP)
+        try container.encodeIfPresent(lastConstructionUpdateTime, forKey: .lastConstructionUpdateTime)
         
         try container.encode(upgradeProgress, forKey: .upgradeProgress)
         try container.encodeIfPresent(upgradeStartTime, forKey: .upgradeStartTime)
@@ -179,18 +186,27 @@ class BuildingData: Codable {
         constructionStartTime = Date().timeIntervalSince1970
         buildersAssigned = max(1, builders)
         constructionProgress = 0.0
+        constructionHP = 0.0
+        lastConstructionUpdateTime = constructionStartTime
     }
     
-    /// Updates construction and returns true if construction completed this frame
+    /// Updates construction and returns true if construction completed this frame.
+    /// Uses incremental HP accumulation so builder count can change mid-build.
     func updateConstruction(currentTime: TimeInterval) -> Bool {
-        guard state == .constructing, let startTime = constructionStartTime else { return false }
-        
-        let elapsed = currentTime - startTime
-        let buildSpeedMultiplier = 1.0 + (Double(buildersAssigned - 1) * 0.5)
-        let effectiveBuildTime = buildingType.buildTime / buildSpeedMultiplier
-        
-        constructionProgress = min(1.0, elapsed / effectiveBuildTime)
-        
+        guard state == .constructing else { return false }
+        guard buildersAssigned > 0 else { return false }  // 0 builders = stalled
+
+        let lastUpdate = lastConstructionUpdateTime ?? constructionStartTime ?? currentTime
+        let delta = currentTime - lastUpdate
+        guard delta > 0 else { return false }
+
+        let baseHPRate = maxHealth / buildingType.buildTime
+        let effective = GameConfig.Construction.effectiveBuilders(count: buildersAssigned)
+        let hpGain = baseHPRate * effective * delta
+        constructionHP = min(maxHealth, constructionHP + hpGain)
+        constructionProgress = constructionHP / maxHealth
+        lastConstructionUpdateTime = currentTime
+
         if constructionProgress >= 1.0 {
             completeConstruction()
             return true
@@ -209,6 +225,7 @@ class BuildingData: Codable {
 
         health = maxHealth
         constructionStartTime = nil
+        lastConstructionUpdateTime = nil
     }
 
     /// Applies the building HP research bonus to maxHealth
@@ -243,13 +260,16 @@ class BuildingData: Codable {
     }
     
     func getRemainingConstructionTime(currentTime: TimeInterval) -> TimeInterval? {
-        guard state == .constructing, let startTime = constructionStartTime else { return nil }
-        
-        let elapsed = currentTime - startTime
-        let buildSpeedMultiplier = 1.0 + (Double(buildersAssigned - 1) * 0.5)
-        let effectiveBuildTime = buildingType.buildTime / buildSpeedMultiplier
-        
-        return max(0, effectiveBuildTime - elapsed)
+        guard state == .constructing else { return nil }
+        guard buildersAssigned > 0 else { return nil }  // stalled, no ETA
+
+        let remainingHP = maxHealth - constructionHP
+        let baseHPRate = maxHealth / buildingType.buildTime
+        let effective = GameConfig.Construction.effectiveBuilders(count: buildersAssigned)
+        let currentRate = baseHPRate * effective
+        guard currentRate > 0 else { return nil }
+
+        return max(0, remainingHP / currentRate)
     }
     
     // MARK: - Upgrade Logic
@@ -383,7 +403,14 @@ class BuildingData: Codable {
     }
 
     // MARK: - Training Logic
-    
+
+    /// Returns the training speed multiplier based on building level for military production buildings.
+    /// Level 1 = 1.0x, Level 2 = 1.1x, Level 3 = 1.2x, etc.
+    func getTrainingSpeedMultiplier() -> Double {
+        guard buildingType.category == .military else { return 1.0 }
+        return 1.0 + Double(level - 1) * GameConfig.Training.buildingLevelSpeedBonusPerLevel
+    }
+
     func canTrain(_ unitType: MilitaryUnitType) -> Bool {
         guard state == .completed else { return false }
         return unitType.trainingBuilding == buildingType
@@ -413,8 +440,11 @@ class BuildingData: Codable {
         var completed: [TrainingQueueEntry] = []
         var completedIndices: [Int] = []
         
+        let buildingSpeedMultiplier = getTrainingSpeedMultiplier()
         for (index, entry) in trainingQueue.enumerated() {
-            let progress = entry.getProgress(currentTime: currentTime)
+            let researchMultiplier = ResearchManager.shared.getMilitaryTrainingSpeedMultiplier()
+            let combinedMultiplier = researchMultiplier * buildingSpeedMultiplier
+            let progress = entry.getProgress(currentTime: currentTime, trainingSpeedMultiplier: combinedMultiplier)
             trainingQueue[index].progress = progress
             
             if progress >= 1.0 {

--- a/Grow2 Shared/Data/BuildingData.swift
+++ b/Grow2 Shared/Data/BuildingData.swift
@@ -668,6 +668,13 @@ class BuildingData: Codable {
         return archerCount + crossbowCount + mangonelCount + trebuchetCount
     }
 
+    // MARK: - Population Capacity
+
+    /// Returns the population capacity for this building at its current level
+    func getPopulationCapacity() -> Int {
+        return buildingType.populationCapacity(forLevel: level)
+    }
+
     // MARK: - Army Home Base Capacity
 
     /// Returns the max number of armies that can use this building as home base.

--- a/Grow2 Shared/Data/GameState.swift
+++ b/Grow2 Shared/Data/GameState.swift
@@ -159,6 +159,11 @@ class GameState: Codable {
         return armies.values.filter { $0.homeBaseID == buildingID }.count
     }
 
+    /// Returns the armies currently using this building as their home base
+    func getArmiesForHomeBase(buildingID: UUID) -> [ArmyData] {
+        return armies.values.filter { $0.homeBaseID == buildingID }
+    }
+
     /// Returns true if the building has room for another army as home base.
     /// City center always returns true (unlimited). Non-home-base buildings return false.
     func hasHomeBaseCapacity(buildingID: UUID) -> Bool {

--- a/Grow2 Shared/Data/GameState.swift
+++ b/Grow2 Shared/Data/GameState.swift
@@ -481,8 +481,8 @@ class GameState: Codable {
                     current += entry.quantity
                 }
 
-                // Add capacity from building type
-                capacity += building.buildingType.populationCapacity
+                // Add capacity from building type (scales with level)
+                capacity += building.buildingType.populationCapacity(forLevel: building.level)
             }
         }
 

--- a/Grow2 Shared/Data/GameStateQueries.swift
+++ b/Grow2 Shared/Data/GameStateQueries.swift
@@ -361,20 +361,20 @@ extension GameState {
             civilianCount += group.villagerCount
         }
 
-        // Count military units in armies
+        // Count military units in armies (pop-space-aware)
         for army in getArmiesForPlayer(id: playerID) {
-            militaryCount += army.getTotalUnits()
+            militaryCount += army.getPopulationUsed()
         }
 
         // Count garrisoned units
         for building in getBuildingsForPlayer(id: playerID) {
             if building.isOperational {
                 civilianCount += building.villagerGarrison
-                militaryCount += building.getTotalGarrisonedUnits()
+                militaryCount += building.getGarrisonPopulation()
 
-                // Count units in training queues
+                // Count units in training queues (pop-space-aware)
                 for entry in building.trainingQueue {
-                    militaryCount += entry.quantity
+                    militaryCount += entry.unitType.popSpace * entry.quantity
                 }
                 for entry in building.villagerTrainingQueue {
                     civilianCount += entry.quantity

--- a/Grow2 Shared/Data/PlayerState.swift
+++ b/Grow2 Shared/Data/PlayerState.swift
@@ -159,7 +159,7 @@ class PlayerState: Codable {
     }
 
     func setCollectionRate(_ type: ResourceTypeData, rate: Double) {
-        collectionRates[type] = max(0, rate)
+        collectionRates[type] = rate
     }
 
     func addResource(_ type: ResourceTypeData, amount: Int, storageCapacity: Int) -> Int {

--- a/Grow2 Shared/Data/ResourcePointData.swift
+++ b/Grow2 Shared/Data/ResourcePointData.swift
@@ -64,7 +64,7 @@ enum ResourcePointTypeData: String, Codable, CaseIterable {
 
     var initialAmount: Int {
         switch self {
-        case .trees: return 100
+        case .trees: return 5000
         case .forage: return 3000
         case .oreMine: return 8000
         case .stoneQuarry: return 6000

--- a/Grow2 Shared/Data/ResourcePointData.swift
+++ b/Grow2 Shared/Data/ResourcePointData.swift
@@ -272,7 +272,7 @@ class ResourcePointData: Codable {
 
     func getCurrentGatherRate(researchMultiplier: Double = 1.0) -> Double {
         let perVillagerRate = 0.2  // Each villager adds 0.2 per second
-        let baseRate = resourceType.baseGatherRate + (Double(totalVillagersGathering) * perVillagerRate)
+        let baseRate = Double(totalVillagersGathering) * perVillagerRate
 
         return baseRate * researchMultiplier
     }

--- a/Grow2 Shared/Engine/AIResearchPlanner.swift
+++ b/Grow2 Shared/Engine/AIResearchPlanner.swift
@@ -150,6 +150,17 @@ struct AIResearchPlanner {
             }
         }
 
+        // Penalize Tier I research in gated branches when gate building isn't built yet
+        // (avoids dead-end research paths where Tier II+ can't be reached)
+        if research.tier == 1, let gateBuilding = research.branch.gateBuildingType {
+            let hasGateBuilding = gameState.getBuildingsForPlayer(id: aiState.playerID).contains {
+                $0.buildingType == gateBuilding && $0.isOperational
+            }
+            if !hasGateBuilding {
+                score -= 5.0
+            }
+        }
+
         return score
     }
 
@@ -175,6 +186,18 @@ struct AIResearchPlanner {
                 if !player.hasCompletedResearch(prereq.rawValue) {
                     prereqsMet = false
                     break
+                }
+            }
+
+            // Check building requirement (e.g. Library for Tier III)
+            if let (buildingType, level) = research.buildingRequirement {
+                let hasBuilding = gameState.getBuildingsForPlayer(id: playerID).contains {
+                    $0.buildingType == buildingType &&
+                    $0.level >= level &&
+                    $0.isOperational
+                }
+                if !hasBuilding {
+                    prereqsMet = false
                 }
             }
 

--- a/Grow2 Shared/Engine/CombatEngine.swift
+++ b/Grow2 Shared/Engine/CombatEngine.swift
@@ -778,17 +778,17 @@ class CombatEngine {
 
         guard !defendingArmies.isEmpty else { return }
 
-        // Find a new home base for retreat (excluding the destroyed building's location)
-        guard let newHomeBase = state.findNearestHomeBase(
-            for: buildingOwnerID,
-            from: building.coordinate,
-            excluding: building.coordinate
-        ) else {
-            debugLog("⚠️ No home base available for retreat - defenders have nowhere to go")
-            return
-        }
-
         for army in defendingArmies {
+            // Find a home base with capacity for each army
+            guard let newHomeBase = state.findHomeBaseWithCapacity(
+                for: buildingOwnerID,
+                from: army.coordinate,
+                excluding: building.id
+            ) else {
+                debugLog("⚠️ No home base available for retreat - \(army.name) has nowhere to go")
+                continue
+            }
+
             // Update home base
             army.homeBaseID = newHomeBase.id
 
@@ -1937,9 +1937,9 @@ class CombatEngine {
             retreatDestination = homeBase.coordinate
         }
 
-        // 2. Fallback: Find nearest valid home base
+        // 2. Fallback: Find nearest valid home base with capacity
         if retreatDestination == nil,
-           let nearestBase = state.findNearestHomeBase(for: ownerID, from: army.coordinate),
+           let nearestBase = state.findHomeBaseWithCapacity(for: ownerID, from: army.coordinate),
            army.coordinate != nearestBase.coordinate {
             retreatBuilding = nearestBase
             retreatDestination = nearestBase.coordinate

--- a/Grow2 Shared/Engine/ConstructionEngine.swift
+++ b/Grow2 Shared/Engine/ConstructionEngine.swift
@@ -193,6 +193,14 @@ class ConstructionEngine {
             }
         }
 
+        // Check library limit (unique building - max 1)
+        if type == .library {
+            let currentCount = state.getBuildingsForPlayer(id: playerID).filter { $0.buildingType == .library }.count
+            if currentCount >= BuildingType.maxLibrariesAllowed() {
+                return (false, "Only one Library allowed per player")
+            }
+        }
+
         // Check resources
         if !player.canAfford(convertBuildCost(type.buildCost)) {
             return (false, "Insufficient resources")

--- a/Grow2 Shared/Engine/GameConfig.swift
+++ b/Grow2 Shared/Engine/GameConfig.swift
@@ -46,6 +46,7 @@ enum GameConfig {
     enum Resources {
         static let baseGatherRatePerVillager: Double = 0.2  // Resources/sec/villager
         static let adjacencyBonusPercent: Double = 0.25     // 25% adjacency bonus
+        static let campLevelBonusPerLevel: Double = 0.10    // +10% gather rate per building level above 1
     }
 
     // MARK: - Terrain
@@ -74,6 +75,7 @@ enum GameConfig {
 
     enum Training {
         static let villagerTrainingTime: TimeInterval = 10.0  // Seconds per villager
+        static let buildingLevelSpeedBonusPerLevel: Double = 0.10  // +10% training speed per building level above 1
     }
 
     // MARK: - Vision

--- a/Grow2 Shared/Engine/GameConfig.swift
+++ b/Grow2 Shared/Engine/GameConfig.swift
@@ -47,6 +47,7 @@ enum GameConfig {
         static let baseGatherRatePerVillager: Double = 0.2  // Resources/sec/villager
         static let adjacencyBonusPercent: Double = 0.25     // 25% adjacency bonus
         static let campLevelBonusPerLevel: Double = 0.10    // +10% gather rate per building level above 1
+        static let farmWoodConsumptionRate: Double = 0.1    // Wood consumed per second per active farm gathering
     }
 
     // MARK: - Terrain

--- a/Grow2 Shared/Engine/GameConfig.swift
+++ b/Grow2 Shared/Engine/GameConfig.swift
@@ -48,10 +48,26 @@ enum GameConfig {
         static let adjacencyBonusPercent: Double = 0.25     // 25% adjacency bonus
     }
 
+    // MARK: - Terrain
+
+    enum Terrain {
+        /// Cost multiplier for building/upgrading on mountain tiles (+25%)
+        static let mountainBuildingCostMultiplier: Double = 1.25
+    }
+
     // MARK: - Construction
 
     enum Construction {
         static let progressChangeThreshold: Double = 0.01  // Min progress to emit event
+        static let diminishingFactor: Double = 0.8
+
+        /// Calculates effective builder count with diminishing returns.
+        /// 0 builders = 0 (stalled), 1 = 1.0x, 2 = 1.8x, 3 = 2.44x, etc.
+        static func effectiveBuilders(count: Int) -> Double {
+            guard count > 0 else { return 0.0 }
+            // Geometric series: (1 - factor^count) / (1 - factor)
+            return (1.0 - pow(diminishingFactor, Double(count))) / (1.0 - diminishingFactor)
+        }
     }
 
     // MARK: - Training

--- a/Grow2 Shared/Engine/GameConfig.swift
+++ b/Grow2 Shared/Engine/GameConfig.swift
@@ -101,10 +101,33 @@ enum GameConfig {
             .market: 2,
             .neighborhood: 2,
             .university: 3,
+            .library: 3,
             .wall: 1,
             .gate: 2,
             .road: 1
         ]
+    }
+
+    // MARK: - Library
+
+    enum Library {
+        /// Research speed bonus per Library level (+10% per level, level 5 = +50%)
+        static let researchSpeedBonusPerLevel: Double = 0.10
+    }
+
+    // MARK: - Defense
+
+    enum Defense {
+        /// HP bonus per building level above 1 for defensive buildings (tower, fort, castle)
+        static let hpBonusPerLevel: Double = 0.20
+        /// Castle: base army home base capacity
+        static let castleBaseArmyCapacity: Int = 3
+        /// Castle: additional army capacity per level above 1
+        static let castleArmyCapacityPerLevel: Int = 1
+        /// Wooden Fort: base army home base capacity
+        static let fortBaseArmyCapacity: Int = 1
+        /// Wooden Fort: additional army capacity per level above 1
+        static let fortArmyCapacityPerLevel: Int = 1
     }
 
     // MARK: - Garrison Defense

--- a/Grow2 Shared/Engine/GameEngine.swift
+++ b/Grow2 Shared/Engine/GameEngine.swift
@@ -170,6 +170,17 @@ class GameEngine {
         if adjustedTime - lastBuildingUpdate >= buildingUpdateInterval {
             let constructionChanges = constructionEngine.update(currentTime: adjustedTime)
             allChanges.append(contentsOf: constructionChanges)
+
+            // Recalculate collection rates when a building upgrade completes (affects camp level bonus)
+            for change in constructionChanges {
+                if case .buildingUpgradeCompleted(let buildingID, _) = change {
+                    if let building = gameState?.getBuilding(id: buildingID),
+                       let ownerID = building.ownerID {
+                        resourceEngine.updateCollectionRates(forPlayer: ownerID)
+                    }
+                }
+            }
+
             lastBuildingUpdate = adjustedTime
         }
 

--- a/Grow2 Shared/Engine/TrainingEngine.swift
+++ b/Grow2 Shared/Engine/TrainingEngine.swift
@@ -317,7 +317,16 @@ class TrainingEngine {
 
         // Create army
         let army = ArmyData(name: "Army", coordinate: spawnCoord, ownerID: playerID)
-        army.homeBaseID = buildingID
+
+        // Assign home base respecting capacity limits
+        if state.hasHomeBaseCapacity(buildingID: buildingID) {
+            army.homeBaseID = buildingID
+        } else if let fallback = state.findHomeBaseWithCapacity(for: playerID, from: spawnCoord, excluding: nil) {
+            army.homeBaseID = fallback.id
+            debugLog("🏠 Army deployed from \(building.buildingType.displayName) but assigned to \(fallback.buildingType.displayName) (capacity full)")
+        } else {
+            army.homeBaseID = buildingID  // No capacity anywhere — assign anyway
+        }
 
         // Add units to army
         for (unitType, count) in composition {

--- a/Grow2 Shared/Managers/BackgroundTimeManager.swift
+++ b/Grow2 Shared/Managers/BackgroundTimeManager.swift
@@ -111,16 +111,21 @@ class BackgroundTimeManager {
         var completedBuildings: [BuildingNode] = []
         
         for building in hexMap.buildings where building.state == .constructing {
-            guard let startTime = building.constructionStartTime else { continue }
-            
-            let totalElapsed = currentTime - startTime
-            let buildSpeedMultiplier = 1.0 + (Double(building.buildersAssigned - 1) * 0.5)
-            let effectiveBuildTime = building.buildingType.buildTime / buildSpeedMultiplier
-            
-            let newProgress = min(1.0, totalElapsed / effectiveBuildTime)
-            building.constructionProgress = newProgress
-            
-            if newProgress >= 1.0 {
+            guard building.buildersAssigned > 0 else { continue }  // stalled
+
+            // Use the incremental HP model to catch up elapsed time
+            let lastUpdate = building.lastConstructionUpdateTime ?? building.constructionStartTime ?? currentTime
+            let delta = currentTime - lastUpdate
+            guard delta > 0 else { continue }
+
+            let baseHPRate = building.maxHealth / building.buildingType.buildTime
+            let effective = GameConfig.Construction.effectiveBuilders(count: building.buildersAssigned)
+            let hpGain = baseHPRate * effective * delta
+            building.constructionHP = min(building.maxHealth, building.constructionHP + hpGain)
+            building.constructionProgress = building.constructionHP / building.maxHealth
+            building.lastConstructionUpdateTime = currentTime
+
+            if building.constructionHP >= building.maxHealth {
                 building.completeConstruction()
                 completedBuildings.append(building)
                 debugLog("  ✅ \(building.buildingType.displayName) completed!")

--- a/Grow2 Shared/Managers/BackgroundTimeManager.swift
+++ b/Grow2 Shared/Managers/BackgroundTimeManager.swift
@@ -61,11 +61,12 @@ class BackgroundTimeManager {
         let manager = ResearchManager.shared
         
         if let active = manager.activeResearch {
-            if active.isComplete(currentTime: currentTime) {
+            let speedMultiplier = manager.getResearchSpeedMultiplier()
+            if active.isComplete(currentTime: currentTime, speedMultiplier: speedMultiplier) {
                 manager.completeResearch(active.researchType)
                 debugLog("  ✅ Research completed: \(active.researchType.displayName)")
             } else {
-                let progress = Int(active.getProgress(currentTime: currentTime) * 100)
+                let progress = Int(active.getProgress(currentTime: currentTime, speedMultiplier: speedMultiplier) * 100)
                 debugLog("  🔬 \(active.researchType.displayName): \(progress)% complete")
             }
         } else {

--- a/Grow2 Shared/Models/Building.swift
+++ b/Grow2 Shared/Models/Building.swift
@@ -28,6 +28,7 @@ enum BuildingType: String, CaseIterable, Codable {
     case lumberCamp = "Lumber Camp"
     case warehouse = "Warehouse"
     case university = "University"
+    case library = "Library"
     case mill = "Mill"
 
     // Infrastructure
@@ -58,7 +59,7 @@ enum BuildingType: String, CaseIterable, Codable {
     
     var category: BuildingCategory {
         switch self {
-        case .cityCenter, .farm, .neighborhood, .blacksmith, .market, .miningCamp, .lumberCamp, .warehouse, .university, .road, .mill:
+        case .cityCenter, .farm, .neighborhood, .blacksmith, .market, .miningCamp, .lumberCamp, .warehouse, .university, .library, .road, .mill:
             return .economic
         case .castle, .barracks, .archeryRange, .stable, .siegeWorkshop, .tower, .woodenFort, .wall, .gate:
             return .military
@@ -76,6 +77,7 @@ enum BuildingType: String, CaseIterable, Codable {
         case .lumberCamp: return "🪓"
         case .warehouse: return "📦"
         case .university: return "🎓"
+        case .library: return "📚"
         case .road: return "🛤️"
         case .castle: return "🏰"
         case .barracks: return "🛡️"
@@ -110,6 +112,8 @@ enum BuildingType: String, CaseIterable, Codable {
             return 1  // Resource camps available early
         case .university:
             return 3  // Same as other advanced economic buildings
+        case .library:
+            return 3  // Requires CC level 3
         case .mill:
             return 2  // Mills available at CC level 2
         case .wall, .gate:
@@ -137,6 +141,8 @@ enum BuildingType: String, CaseIterable, Codable {
             return [.wood: 120, .stone: 80]
         case .university:
             return [.wood: 150, .stone: 120, .ore: 60]
+        case .library:
+            return [.wood: 120, .stone: 100, .ore: 40]
         case .road:
             return [.stone: 10]
         case .castle:
@@ -173,6 +179,7 @@ enum BuildingType: String, CaseIterable, Codable {
         case .lumberCamp: return 25.0
         case .warehouse: return 30.0
         case .university: return 50.0
+        case .library: return 45.0
         case .road: return 5.0  // Quick to build
         case .castle: return 90.0
         case .barracks: return 4.0
@@ -272,6 +279,7 @@ enum BuildingType: String, CaseIterable, Codable {
         case .lumberCamp: return "Increases wood collection"
         case .warehouse: return "Stores extra resources"
         case .university: return "Research technologies"
+        case .library: return "Boosts research speed and unlocks advanced research"
         case .road: return "Increases movement speed for units"
         case .castle: return "Defensive stronghold and military hub"
         case .barracks: return "Trains infantry units"
@@ -391,6 +399,11 @@ enum BuildingType: String, CaseIterable, Codable {
         case 3: return 8   // 3rd warehouse requires CC level 8
         default: return 99 // No more than 3 allowed
         }
+    }
+
+    /// Maximum number of Libraries allowed per player (unique building)
+    static func maxLibrariesAllowed() -> Int {
+        return 1
     }
 }
 
@@ -665,6 +678,7 @@ class BuildingNode: SKSpriteNode {
     }
     
     func getTotalGarrisonedUnits() -> Int { data.getTotalGarrisonedUnits() }
+    func getGarrisonPopulation() -> Int { data.getGarrisonPopulation() }
     func getTotalGarrisonCount() -> Int { data.getTotalGarrisonCount() }
     func getGarrisonCapacity() -> Int { data.getGarrisonCapacity() }
     func hasGarrisonSpace(for count: Int) -> Bool { data.hasGarrisonSpace(for: count) }

--- a/Grow2 Shared/Models/Building.swift
+++ b/Grow2 Shared/Models/Building.swift
@@ -56,6 +56,20 @@ enum BuildingType: String, CaseIterable, Codable {
         default: return 0
         }
     }
+
+    /// Population capacity bonus per level (added to base per level above 1)
+    var populationCapacityPerLevel: Int {
+        switch self {
+        case .cityCenter: return 5
+        case .neighborhood: return 3
+        default: return 0
+        }
+    }
+
+    /// Returns the population capacity for this building at a given level
+    func populationCapacity(forLevel level: Int) -> Int {
+        return populationCapacity + (populationCapacityPerLevel * (level - 1))
+    }
     
     var category: BuildingCategory {
         switch self {

--- a/Grow2 Shared/Models/MilitaryUnit.swift
+++ b/Grow2 Shared/Models/MilitaryUnit.swift
@@ -81,6 +81,15 @@ enum TrainableUnitType: Codable {
             return "Gathers resources and constructs buildings"
         }
     }
+
+    var popSpace: Int {
+        switch self {
+        case .military(let type):
+            return type.popSpace
+        case .villager:
+            return 1
+        }
+    }
 }
 
 // MARK: - Research Manager Integration

--- a/Grow2 Shared/Models/Player.swift
+++ b/Grow2 Shared/Models/Player.swift
@@ -363,7 +363,7 @@ class Player {
     func getPopulationCapacity() -> Int {
         let buildingCapacity = buildings
             .filter { $0.isOperational }
-            .reduce(0) { $0 + $1.buildingType.populationCapacity }
+            .reduce(0) { $0 + $1.buildingType.populationCapacity(forLevel: $1.level) }
 
         // Add research bonus for population capacity
         let researchBonus = ResearchManager.shared.getPopulationCapacityBonus()

--- a/Grow2 Shared/Models/Player.swift
+++ b/Grow2 Shared/Models/Player.swift
@@ -373,32 +373,32 @@ class Player {
         
     func getCurrentPopulation() -> Int {
         var total = 0
-        
+
         // Count villagers on field
         total += getTotalVillagerCount()
-        
-        // Count military units in armies
-        total += getTotalMilitaryUnits()
-        
+
+        // Count military units in armies (pop-space-aware)
+        total += getArmies().reduce(0) { $0 + $1.getPopulationUsed() }
+
         // Count garrisoned units in buildings
         for building in buildings {
             total += building.villagerGarrison
-            total += building.getTotalGarrisonedUnits()
+            total += building.getGarrisonPopulation()
         }
-        
+
         // Count units currently in training queues
         for building in buildings {
-            // Military training queue
+            // Military training queue (pop-space-aware)
             for entry in building.trainingQueue {
-                total += entry.quantity
+                total += entry.unitType.popSpace * entry.quantity
             }
-            
+
             // Villager training queue
             for entry in building.villagerTrainingQueue {
                 total += entry.quantity
             }
         }
-        
+
         return total
     }
         
@@ -414,10 +414,10 @@ class Player {
     
     /// Returns the food consumption rate per second based on current population
     func getFoodConsumptionRate() -> Double {
-        // Calculate military population
-        let militaryPopulation = getTotalMilitaryUnits()
-        // Include garrisoned military units
-        let garrisonedMilitary = buildings.reduce(0) { $0 + $1.getTotalGarrisonedUnits() }
+        // Calculate military population (pop-space-aware)
+        let militaryPopulation = getArmies().reduce(0) { $0 + $1.getPopulationUsed() }
+        // Include garrisoned military units (pop-space-aware)
+        let garrisonedMilitary = buildings.reduce(0) { $0 + $1.getGarrisonPopulation() }
         let totalMilitary = militaryPopulation + garrisonedMilitary
 
         // Calculate civilian population (villagers + garrisoned villagers + training)

--- a/Grow2 Shared/Models/Resource.swift
+++ b/Grow2 Shared/Models/Resource.swift
@@ -123,7 +123,7 @@ class ResourcePointNode: SKSpriteNode {
     var currentGatherRate: Double {
         let villagerCount = getTotalVillagersGathering()
         let perVillagerRate = 0.2  // Each villager adds 0.2 per second
-        let baseRate = resourceType.baseGatherRate + (Double(villagerCount) * perVillagerRate)
+        let baseRate = Double(villagerCount) * perVillagerRate
 
         // Apply research bonuses based on resource type
         let researchManager = ResearchManager.shared

--- a/Grow2 Shared/Nodes/Map Entity.swift
+++ b/Grow2 Shared/Nodes/Map Entity.swift
@@ -248,7 +248,11 @@ class Army: MapEntity {
     func getTotalUnits() -> Int {
         return data.getTotalUnits()
     }
-    
+
+    func getPopulationUsed() -> Int {
+        return data.getPopulationUsed()
+    }
+
     // ✅ UPDATED: Handle optional commander with category-based specialty bonuses using combatStats
     func getModifiedStrength() -> Double {
         let aggregatedStats = getAggregatedCombatStats()

--- a/Grow2 Shared/Notifications/NotificationManager.swift
+++ b/Grow2 Shared/Notifications/NotificationManager.swift
@@ -519,11 +519,7 @@ class NotificationManager {
         for building in gameState.buildings.values {
             guard building.ownerID == localPlayerID,
                   building.state == .constructing,
-                  let startTime = building.constructionStartTime else { continue }
-
-            let buildSpeedMultiplier = 1.0 + (Double(building.buildersAssigned - 1) * 0.5)
-            let totalTime = building.buildingType.buildTime / buildSpeedMultiplier
-            let delay = (startTime + totalTime) - now
+                  let delay = building.getRemainingConstructionTime(currentTime: now) else { continue }
             if delay > 1 {
                 scheduleDelayedNotification(
                     body: "🏗️ \(building.buildingType.displayName) construction complete",

--- a/Grow2 Shared/Notifications/NotificationManager.swift
+++ b/Grow2 Shared/Notifications/NotificationManager.swift
@@ -578,7 +578,8 @@ class NotificationManager {
 
         // Research
         if let active = ResearchManager.shared.activeResearch {
-            let delay = active.getRemainingTime(currentTime: now)
+            let speedMultiplier = ResearchManager.shared.getResearchSpeedMultiplier()
+            let delay = active.getRemainingTime(currentTime: now, speedMultiplier: speedMultiplier)
             if delay > 1 {
                 scheduleDelayedNotification(
                     body: "🔬 \(active.researchType.displayName) research complete",

--- a/Grow2 Shared/Scene/GameScene.swift
+++ b/Grow2 Shared/Scene/GameScene.swift
@@ -1724,17 +1724,13 @@ class GameScene: SKScene, BuildingPlacementDelegate, ReinforcementManagerDelegat
         case .constructing:
             let progress = Int(building.constructionProgress * 100)
             message += "Status: Under Construction (\(progress)%)\n"
-            if let startTime = building.constructionStartTime {
-                let currentTime = Date().timeIntervalSince1970
-                let elapsed = currentTime - startTime
-                let buildSpeedMultiplier = 1.0 + (Double(building.buildersAssigned - 1) * 0.5)
-                let effectiveBuildTime = building.buildingType.buildTime / buildSpeedMultiplier
-                let remaining = max(0, effectiveBuildTime - elapsed)
+            let currentTime = Date().timeIntervalSince1970
+            if let remaining = building.data.getRemainingConstructionTime(currentTime: currentTime) {
                 let minutes = Int(remaining) / 60
                 let seconds = Int(remaining) % 60
                 message += "Time Remaining: \(minutes)m \(seconds)s\n"
-                message += "Builders: \(building.buildersAssigned)\n"
             }
+            message += "Builders: \(building.buildersAssigned)\n"
         case .completed:
             message += "Status: Completed ✓\n"
             message += "Health: \(building.health)/\(building.maxHealth)\n"

--- a/Grow2 Shared/Scene/GameScene.swift
+++ b/Grow2 Shared/Scene/GameScene.swift
@@ -1086,7 +1086,10 @@ class GameScene: SKScene, BuildingPlacementDelegate, ReinforcementManagerDelegat
 
         // Resource display update (reuse existing lastUpdateTime)
         if lastUpdateTime == nil || currentTime - lastUpdateTime! >= 0.5 {
-            player?.updateResources(currentTime: realWorldTime)
+            // When engine is enabled, ResourceEngine handles resource addition and food consumption
+            if !isEngineEnabled {
+                player?.updateResources(currentTime: realWorldTime)
+            }
             gameDelegate?.gameSceneDidUpdateResources(self)
             lastUpdateTime = currentTime
         }

--- a/Grow2 Shared/Visual/GameVisualLayer.swift
+++ b/Grow2 Shared/Visual/GameVisualLayer.swift
@@ -361,10 +361,7 @@ class GameVisualLayer {
 
     private func handleBuildingUpgradeCompleted(buildingID: UUID, newLevel: Int) {
         guard let buildingNode = buildingNodes[buildingID] else { return }
-        buildingNode.data.level = newLevel
-        buildingNode.data.state = .completed
-        buildingNode.updateAppearance()
-        buildingNode.removeUpgradeBar()
+        buildingNode.completeUpgrade()
     }
 
     private func handleBuildingDemolitionStarted(buildingID: UUID) {

--- a/Grow2 iOS/Coordinators/MenuCoordinator+TileMenus.swift
+++ b/Grow2 iOS/Coordinators/MenuCoordinator+TileMenus.swift
@@ -99,9 +99,12 @@ extension MenuCoordinator {
                 title = "\(resourcePoint.resourceType.icon) \(resourcePoint.resourceType.displayName)"
 
                 let gatherers = resourcePoint.getTotalVillagersGathering()
-                message = "Remaining: \(resourcePoint.remainingAmount)"
+                let yieldName = resourcePoint.resourceType.resourceYield.displayName
+                message = "Remaining: \(resourcePoint.remainingAmount) \(yieldName)"
                 if gatherers > 0 {
                     message += "\n👷 \(gatherers) villager(s) gathering"
+                } else {
+                    message += "\nNot being gathered"
                 }
 
                 if resourcePoint.resourceType.requiresCamp {

--- a/Grow2 iOS/Coordinators/MenuCoordinator.swift
+++ b/Grow2 iOS/Coordinators/MenuCoordinator.swift
@@ -219,6 +219,12 @@ class MenuCoordinator {
             let requiredCCLevel = type.requiredCityCenterLevel
             guard cityCenterLevel >= requiredCCLevel else { continue }
 
+            // Skip Library if player already has one (completed, constructing, or upgrading)
+            if type == .library {
+                let existingLibraries = player.buildings.filter { $0.buildingType == .library }
+                if !existingLibraries.isEmpty { continue }
+            }
+
             // Check basic placement
             // For multi-tile buildings, check if ANY rotation (0-5) allows valid placement
             let canPlace: Bool

--- a/Grow2 iOS/ViewControllers/BuildingDetailViewController+HomeBase.swift
+++ b/Grow2 iOS/ViewControllers/BuildingDetailViewController+HomeBase.swift
@@ -1,0 +1,81 @@
+// ============================================================================
+// FILE: BuildingDetailViewController+HomeBase.swift
+// PURPOSE: Home base section UI for BuildingDetailViewController
+//          Shows army capacity and list of armies based at this building
+// ============================================================================
+
+import UIKit
+
+// MARK: - Home Base Section
+
+extension BuildingDetailViewController {
+
+    func setupHomeBaseSection(yOffset: CGFloat, contentWidth: CGFloat, leftMargin: CGFloat) -> CGFloat {
+        var currentY = yOffset
+
+        // Section header
+        let sectionLabel = createLabel(
+            text: "🏠 Home Base",
+            fontSize: 18,
+            weight: .semibold,
+            color: .white
+        )
+        sectionLabel.frame = CGRect(x: leftMargin, y: currentY, width: contentWidth, height: 25)
+        contentView.addSubview(sectionLabel)
+        currentY += 35
+
+        // Capacity line
+        let buildingData = building.data
+        let currentCount = GameEngine.shared.gameState?.getArmyCountForHomeBase(buildingID: buildingData.id) ?? 0
+        let capacity = buildingData.getArmyHomeBaseCapacity()
+
+        let capacityText: String
+        if capacity == nil {
+            capacityText = "Army Capacity: \(currentCount) (Unlimited)"
+        } else if let cap = capacity {
+            capacityText = "Army Capacity: \(currentCount)/\(cap)"
+        } else {
+            capacityText = "Army Capacity: \(currentCount)"
+        }
+
+        let capacityLabel = createLabel(
+            text: capacityText,
+            fontSize: 15,
+            color: UIColor(white: 0.85, alpha: 1.0)
+        )
+        capacityLabel.frame = CGRect(x: leftMargin, y: currentY, width: contentWidth, height: 22)
+        contentView.addSubview(capacityLabel)
+        currentY += 30
+
+        // Army list
+        let armies = GameEngine.shared.gameState?.getArmiesForHomeBase(buildingID: buildingData.id) ?? []
+
+        if armies.isEmpty {
+            let emptyLabel = createLabel(
+                text: "No armies based here",
+                fontSize: 13,
+                color: UIColor(white: 0.5, alpha: 1.0)
+            )
+            emptyLabel.frame = CGRect(x: leftMargin, y: currentY, width: contentWidth, height: 20)
+            contentView.addSubview(emptyLabel)
+            currentY += 30
+        } else {
+            for army in armies {
+                let unitCount = army.getTotalUnits()
+                let coord = army.coordinate
+                let armyText = "\(army.name) — \(unitCount) units at (\(coord.q), \(coord.r))"
+
+                let armyLabel = createLabel(
+                    text: armyText,
+                    fontSize: 13,
+                    color: UIColor(white: 0.75, alpha: 1.0)
+                )
+                armyLabel.frame = CGRect(x: leftMargin + 10, y: currentY, width: contentWidth - 10, height: 20)
+                contentView.addSubview(armyLabel)
+                currentY += 24
+            }
+        }
+
+        return currentY + 10
+    }
+}

--- a/Grow2 iOS/ViewControllers/BuildingDetailViewController+Training.swift
+++ b/Grow2 iOS/ViewControllers/BuildingDetailViewController+Training.swift
@@ -121,6 +121,7 @@ extension BuildingDetailViewController {
     /// Calculate the maximum number of units that can be trained based on resources and population
     func calculateMaxTrainable(unitType: TrainableUnitType) -> Int {
         let availablePop = player.getAvailablePopulation()
+        let maxByPop = availablePop / unitType.popSpace
 
         var maxAffordable = Int.max
         for (resourceType, costPerUnit) in unitType.trainingCost {
@@ -131,7 +132,7 @@ extension BuildingDetailViewController {
             }
         }
 
-        let maxTrainable = min(availablePop, maxAffordable)
+        let maxTrainable = min(maxByPop, maxAffordable)
         return min(maxTrainable, 50)
     }
 
@@ -250,7 +251,8 @@ extension BuildingDetailViewController {
         }
 
         let availablePop = player.getAvailablePopulation()
-        maxAffordable = min(maxAffordable, availablePop)
+        let maxByPop = availablePop / unitType.popSpace
+        maxAffordable = min(maxAffordable, maxByPop)
 
         let sliderMax = max(1, min(maxAffordable, 20))
         let canTrain = maxAffordable >= 1

--- a/Grow2 iOS/ViewControllers/BuildingDetailViewController+Training.swift
+++ b/Grow2 iOS/ViewControllers/BuildingDetailViewController+Training.swift
@@ -61,12 +61,35 @@ extension BuildingDetailViewController {
         if costReduction > 0 {
             costText += " (-\(Int(costReduction * 100))% 📦)"
         }
-        let costLabel = UILabel(frame: CGRect(x: 15, y: 35, width: contentWidth - 30, height: 20))
+        let costLabel = UILabel(frame: CGRect(x: 15, y: 35, width: contentWidth - 140, height: 20))
         costLabel.text = "Cost: \(costText)"
         costLabel.font = UIFont.systemFont(ofSize: 12)
         costLabel.textColor = costReduction > 0 ? UIColor(red: 0.5, green: 0.9, blue: 0.5, alpha: 1.0) : UIColor(white: 0.7, alpha: 1.0)
         costLabel.tag = 1000 + index
         container.addSubview(costLabel)
+
+        // Training time per unit
+        let effectiveTime: TimeInterval
+        switch unitType {
+        case .villager:
+            effectiveTime = GameConfig.Training.villagerTrainingTime
+        case .military:
+            let buildingMultiplier = building.data.getTrainingSpeedMultiplier()
+            let researchMultiplier = ResearchManager.shared.getMilitaryTrainingSpeedMultiplier()
+            effectiveTime = unitType.trainingTime / (buildingMultiplier * researchMultiplier)
+        }
+        let timeText: String
+        if effectiveTime == effectiveTime.rounded() {
+            timeText = "\u{23F1}\u{FE0F} \(Int(effectiveTime))s each"
+        } else {
+            timeText = "\u{23F1}\u{FE0F} \(String(format: "%.1f", effectiveTime))s each"
+        }
+        let timeLabel = UILabel(frame: CGRect(x: contentWidth - 110, y: 35, width: 95, height: 20))
+        timeLabel.text = timeText
+        timeLabel.font = UIFont.systemFont(ofSize: 12)
+        timeLabel.textColor = UIColor(white: 0.7, alpha: 1.0)
+        timeLabel.textAlignment = .right
+        container.addSubview(timeLabel)
 
         // Calculate max trainable based on resources and population
         let maxTrainable = calculateMaxTrainable(unitType: unitType)

--- a/Grow2 iOS/ViewControllers/BuildingDetailViewController.swift
+++ b/Grow2 iOS/ViewControllers/BuildingDetailViewController.swift
@@ -465,10 +465,13 @@ class BuildingDetailViewController: UIViewController {
     func getQueueDisplayText() -> String {
         var text = ""
         let currentTime = Date().timeIntervalSince1970
-        
+        let researchMultiplier = ResearchManager.shared.getMilitaryTrainingSpeedMultiplier()
+        let buildingMultiplier = building.data.getTrainingSpeedMultiplier()
+        let combinedMultiplier = researchMultiplier * buildingMultiplier
+
         // Military training queue
         for entry in building.trainingQueue {
-            let progress = entry.getProgress(currentTime: currentTime)
+            let progress = entry.getProgress(currentTime: currentTime, trainingSpeedMultiplier: combinedMultiplier)
             let progressPercent = Int(progress * 100)
             text += "\(entry.unitType.icon) \(entry.quantity)x \(entry.unitType.displayName) - \(progressPercent)%\n"
         }

--- a/Grow2 iOS/ViewControllers/BuildingDetailViewController.swift
+++ b/Grow2 iOS/ViewControllers/BuildingDetailViewController.swift
@@ -290,6 +290,11 @@ class BuildingDetailViewController: UIViewController {
             }
         }
 
+        // Home base section (forts, castles, city centers)
+        if Army.canBeHomeBase(building.buildingType) && building.state == .completed {
+            yOffset = setupHomeBaseSection(yOffset: yOffset, contentWidth: contentWidth, leftMargin: leftMargin)
+        }
+
         // ✅ FIX 6: Upgrade section with proper debug logging
         debugLog("🔧 DEBUG - Upgrade section check:")
         debugLog("   state: \(building.state)")

--- a/Grow2 iOS/ViewControllers/GameViewController.swift
+++ b/Grow2 iOS/ViewControllers/GameViewController.swift
@@ -679,8 +679,13 @@ class GameViewController: UIViewController {
                     label.textColor = .systemGreen
                 }
             } else {
-                label.textColor = textColor
-                label.text = "\(resourceType.icon) \(amount)/\(cap) (+\(String(format: "%.1f", rate))/s)"
+                let sign = rate >= 0 ? "+" : ""
+                if rate < 0 {
+                    label.textColor = .systemRed
+                } else {
+                    label.textColor = textColor
+                }
+                label.text = "\(resourceType.icon) \(amount)/\(cap) (\(sign)\(String(format: "%.1f", rate))/s)"
             }
         }
         

--- a/Grow2 iOS/ViewControllers/ResearchViewController.swift
+++ b/Grow2 iOS/ViewControllers/ResearchViewController.swift
@@ -1,18 +1,18 @@
 // ============================================================================
 // FILE: ResearchViewController.swift
-// LOCATION: Grow2 iOS/ViewControllers/ResearchViewController.swift (new file)
+// LOCATION: Grow2 iOS/ViewControllers/ResearchViewController.swift
+// PURPOSE: Research tree UI with branching visual layout and dependency lines
 // ============================================================================
 
 import UIKit
 
-class ResearchViewController: UIViewController, UITableViewDelegate, UITableViewDataSource {
-    
+class ResearchViewController: UIViewController {
+
     // MARK: - Properties
-    
+
     weak var player: Player?
-    
+
     // UI Elements
-    private var tableView: UITableView!
     private var headerView: UIView!
     private var segmentedControl: UISegmentedControl!
     private var activeResearchView: UIView!
@@ -21,235 +21,423 @@ class ResearchViewController: UIViewController, UITableViewDelegate, UITableView
     private var activeProgressFill: UIView!
     private var activeTimeLabel: UILabel!
     private var cancelButton: UIButton!
+    private var treeScrollView: UIScrollView!
+    private var treeContentView: UIView!
 
     private var updateTimer: Timer?
-
-    // Group research by category
-    private var researchByCategory: [ResearchCategory: [ResearchType]] = [:]
     private var selectedCategory: ResearchCategory = .economic
-    
+
+    // Tree layout storage
+    private var nodeViews: [ResearchType: ResearchNodeView] = [:]
+    private var lineLayer: CAShapeLayer?
+    private var crossLineLayer: CAShapeLayer?
+
+    // Layout constants
+    private let nodeWidth: CGFloat = 110
+    private let nodeHeight: CGFloat = 45
+    private let tierSpacing: CGFloat = 20   // horizontal gap between tiers
+    private let lineSpacing: CGFloat = 12   // vertical gap between lines in a branch
+    private let branchSpacing: CGFloat = 18 // vertical gap between branches
+    private let branchHeaderHeight: CGFloat = 36
+    private let treeLeftPadding: CGFloat = 15
+    private let treeTopPadding: CGFloat = 10
+
     // MARK: - Lifecycle
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
-        organizeResearch()
         setupUI()
-        
-        // Start update timer
+        buildTree()
+
         updateTimer = Timer.scheduledTimer(withTimeInterval: 0.5, repeats: true) { [weak self] _ in
             self?.updateActiveResearchDisplay()
-            self?.tableView.reloadData()
+            self?.updateNodeStates()
         }
     }
-    
+
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         updateTimer?.invalidate()
         updateTimer = nil
     }
-    
+
     // MARK: - Setup
-    
-    private func organizeResearch() {
-        researchByCategory.removeAll()
 
-        for research in ResearchType.allCases {
-            let category = research.category
-            if researchByCategory[category] == nil {
-                researchByCategory[category] = []
-            }
-            researchByCategory[category]?.append(research)
-        }
-
-        // Sort research within each category by tier, then by name
-        for category in researchByCategory.keys {
-            researchByCategory[category]?.sort { r1, r2 in
-                if r1.tier != r2.tier {
-                    return r1.tier < r2.tier
-                }
-                return r1.displayName < r2.displayName
-            }
-        }
-    }
-    
     private func setupUI() {
         view.backgroundColor = UIColor(white: 0.15, alpha: 1.0)
-        
+
         // Header
-        headerView = UIView(frame: CGRect(x: 0, y: 0, width: view.bounds.width, height: 60))
+        headerView = UIView()
         headerView.backgroundColor = UIColor(white: 0.1, alpha: 0.95)
+        headerView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(headerView)
-        
-        // Title
-        let titleLabel = UILabel(frame: CGRect(x: 20, y: 15, width: 200, height: 30))
-        titleLabel.text = "🔬 Research"
-        titleLabel.font = UIFont.boldSystemFont(ofSize: 24)
+
+        let titleLabel = UILabel()
+        titleLabel.text = "Research"
+        titleLabel.font = UIFont.boldSystemFont(ofSize: 22)
         titleLabel.textColor = .white
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
         headerView.addSubview(titleLabel)
-        
-        // Close button
-        let closeButton = UIButton(frame: CGRect(x: view.bounds.width - 70, y: 10, width: 50, height: 40))
-        closeButton.setTitle("✕", for: .normal)
-        closeButton.titleLabel?.font = UIFont.systemFont(ofSize: 28, weight: .bold)
+
+        let closeButton = UIButton(type: .system)
+        closeButton.setTitle("X", for: .normal)
+        closeButton.titleLabel?.font = UIFont.systemFont(ofSize: 22, weight: .bold)
         closeButton.setTitleColor(.white, for: .normal)
         closeButton.backgroundColor = UIColor(white: 0.3, alpha: 0.8)
         closeButton.layer.cornerRadius = 8
         closeButton.addTarget(self, action: #selector(closeTapped), for: .touchUpInside)
+        closeButton.translatesAutoresizingMaskIntoConstraints = false
         headerView.addSubview(closeButton)
-        
-        // Segmented Control for tabs
-        setupSegmentedControl()
 
-        // Active Research Panel
-        setupActiveResearchPanel()
-
-        // Table View
-        let tableY = activeResearchView.frame.maxY + 10
-        tableView = UITableView(frame: CGRect(x: 0, y: tableY, width: view.bounds.width, height: view.bounds.height - tableY), style: .plain)
-        tableView.delegate = self
-        tableView.dataSource = self
-        tableView.backgroundColor = .clear
-        tableView.separatorStyle = .none
-        tableView.register(ResearchCell.self, forCellReuseIdentifier: "ResearchCell")
-        view.addSubview(tableView)
-    }
-    
-    private func setupSegmentedControl() {
+        // Segmented Control
         let economicTitle = "\(ResearchCategory.economic.icon) Economic"
         let militaryTitle = "\(ResearchCategory.military.icon) Military"
         segmentedControl = UISegmentedControl(items: [economicTitle, militaryTitle])
-        segmentedControl.frame = CGRect(x: 15, y: 70, width: view.bounds.width - 30, height: 36)
         segmentedControl.selectedSegmentIndex = 0
         segmentedControl.backgroundColor = UIColor(white: 0.2, alpha: 1.0)
         segmentedControl.selectedSegmentTintColor = UIColor(red: 0.3, green: 0.5, blue: 0.7, alpha: 1.0)
         segmentedControl.setTitleTextAttributes([.foregroundColor: UIColor.white], for: .normal)
         segmentedControl.setTitleTextAttributes([.foregroundColor: UIColor.white], for: .selected)
         segmentedControl.addTarget(self, action: #selector(segmentChanged), for: .valueChanged)
+        segmentedControl.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(segmentedControl)
-    }
 
-    @objc private func segmentChanged() {
-        selectedCategory = segmentedControl.selectedSegmentIndex == 0 ? .economic : .military
-        tableView.reloadData()
+        // Active Research Panel
+        setupActiveResearchPanel()
+
+        // Tree scroll view
+        treeScrollView = UIScrollView()
+        treeScrollView.backgroundColor = .clear
+        treeScrollView.showsHorizontalScrollIndicator = true
+        treeScrollView.showsVerticalScrollIndicator = true
+        treeScrollView.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(treeScrollView)
+
+        treeContentView = UIView()
+        treeContentView.backgroundColor = .clear
+        treeScrollView.addSubview(treeContentView)
+
+        // Layout constraints
+        NSLayoutConstraint.activate([
+            headerView.topAnchor.constraint(equalTo: view.topAnchor),
+            headerView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            headerView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            headerView.heightAnchor.constraint(equalToConstant: 50),
+
+            titleLabel.leadingAnchor.constraint(equalTo: headerView.leadingAnchor, constant: 20),
+            titleLabel.centerYAnchor.constraint(equalTo: headerView.centerYAnchor),
+
+            closeButton.trailingAnchor.constraint(equalTo: headerView.trailingAnchor, constant: -15),
+            closeButton.centerYAnchor.constraint(equalTo: headerView.centerYAnchor),
+            closeButton.widthAnchor.constraint(equalToConstant: 44),
+            closeButton.heightAnchor.constraint(equalToConstant: 36),
+
+            segmentedControl.topAnchor.constraint(equalTo: headerView.bottomAnchor, constant: 8),
+            segmentedControl.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 15),
+            segmentedControl.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -15),
+            segmentedControl.heightAnchor.constraint(equalToConstant: 32),
+
+            activeResearchView.topAnchor.constraint(equalTo: segmentedControl.bottomAnchor, constant: 8),
+            activeResearchView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 15),
+            activeResearchView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -15),
+            activeResearchView.heightAnchor.constraint(equalToConstant: 80),
+
+            treeScrollView.topAnchor.constraint(equalTo: activeResearchView.bottomAnchor, constant: 8),
+            treeScrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            treeScrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            treeScrollView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+        ])
     }
 
     private func setupActiveResearchPanel() {
-        activeResearchView = UIView(frame: CGRect(x: 15, y: 116, width: view.bounds.width - 30, height: 100))
+        activeResearchView = UIView()
         activeResearchView.backgroundColor = UIColor(white: 0.2, alpha: 1.0)
-        activeResearchView.layer.cornerRadius = 12
+        activeResearchView.layer.cornerRadius = 10
+        activeResearchView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(activeResearchView)
-        
-        // "Current Research" label
-        let currentLabel = UILabel(frame: CGRect(x: 15, y: 10, width: 200, height: 20))
+
+        let currentLabel = UILabel()
         currentLabel.text = "Current Research"
-        currentLabel.font = UIFont.systemFont(ofSize: 14, weight: .medium)
-        currentLabel.textColor = UIColor(white: 0.7, alpha: 1.0)
+        currentLabel.font = UIFont.systemFont(ofSize: 12, weight: .medium)
+        currentLabel.textColor = UIColor(white: 0.6, alpha: 1.0)
+        currentLabel.translatesAutoresizingMaskIntoConstraints = false
         activeResearchView.addSubview(currentLabel)
-        
-        // Active research name
-        activeResearchLabel = UILabel(frame: CGRect(x: 15, y: 32, width: activeResearchView.bounds.width - 100, height: 25))
-        activeResearchLabel.font = UIFont.boldSystemFont(ofSize: 18)
+
+        activeResearchLabel = UILabel()
+        activeResearchLabel.font = UIFont.boldSystemFont(ofSize: 16)
         activeResearchLabel.textColor = .white
         activeResearchLabel.text = "None"
+        activeResearchLabel.translatesAutoresizingMaskIntoConstraints = false
         activeResearchView.addSubview(activeResearchLabel)
-        
-        // Progress bar background
-        let progressBarBg = UIView(frame: CGRect(x: 15, y: 62, width: activeResearchView.bounds.width - 30, height: 12))
-        progressBarBg.backgroundColor = UIColor(white: 0.3, alpha: 1.0)
-        progressBarBg.layer.cornerRadius = 6
-        activeResearchView.addSubview(progressBarBg)
-        
-        // Progress bar fill
-        activeProgressFill = UIView(frame: CGRect(x: 0, y: 0, width: 0, height: 12))
+
+        let progressBg = UIView()
+        progressBg.backgroundColor = UIColor(white: 0.3, alpha: 1.0)
+        progressBg.layer.cornerRadius = 4
+        progressBg.translatesAutoresizingMaskIntoConstraints = false
+        activeResearchView.addSubview(progressBg)
+
+        activeProgressFill = UIView()
         activeProgressFill.backgroundColor = UIColor(red: 0.3, green: 0.7, blue: 0.9, alpha: 1.0)
-        activeProgressFill.layer.cornerRadius = 6
-        progressBarBg.addSubview(activeProgressFill)
-        
-        activeProgressBar = progressBarBg
-        
-        // Time remaining label
-        activeTimeLabel = UILabel(frame: CGRect(x: 15, y: 78, width: activeResearchView.bounds.width - 30, height: 18))
-        activeTimeLabel.font = UIFont.monospacedDigitSystemFont(ofSize: 13, weight: .medium)
-        activeTimeLabel.textColor = UIColor(white: 0.8, alpha: 1.0)
+        activeProgressFill.layer.cornerRadius = 4
+        progressBg.addSubview(activeProgressFill)
+        activeProgressBar = progressBg
+
+        activeTimeLabel = UILabel()
+        activeTimeLabel.font = UIFont.monospacedDigitSystemFont(ofSize: 11, weight: .medium)
+        activeTimeLabel.textColor = UIColor(white: 0.7, alpha: 1.0)
         activeTimeLabel.textAlignment = .center
+        activeTimeLabel.translatesAutoresizingMaskIntoConstraints = false
         activeResearchView.addSubview(activeTimeLabel)
-        
-        // Cancel button
-        cancelButton = UIButton(frame: CGRect(x: activeResearchView.bounds.width - 80, y: 25, width: 65, height: 30))
+
+        cancelButton = UIButton(type: .system)
         cancelButton.setTitle("Cancel", for: .normal)
-        cancelButton.titleLabel?.font = UIFont.systemFont(ofSize: 13, weight: .medium)
+        cancelButton.titleLabel?.font = UIFont.systemFont(ofSize: 12, weight: .medium)
+        cancelButton.setTitleColor(.white, for: .normal)
         cancelButton.backgroundColor = UIColor(red: 0.7, green: 0.3, blue: 0.3, alpha: 1.0)
-        cancelButton.layer.cornerRadius = 6
+        cancelButton.layer.cornerRadius = 5
         cancelButton.addTarget(self, action: #selector(cancelResearchTapped), for: .touchUpInside)
+        cancelButton.translatesAutoresizingMaskIntoConstraints = false
         activeResearchView.addSubview(cancelButton)
-        
+
+        NSLayoutConstraint.activate([
+            currentLabel.topAnchor.constraint(equalTo: activeResearchView.topAnchor, constant: 8),
+            currentLabel.leadingAnchor.constraint(equalTo: activeResearchView.leadingAnchor, constant: 12),
+
+            activeResearchLabel.topAnchor.constraint(equalTo: currentLabel.bottomAnchor, constant: 2),
+            activeResearchLabel.leadingAnchor.constraint(equalTo: activeResearchView.leadingAnchor, constant: 12),
+            activeResearchLabel.trailingAnchor.constraint(equalTo: cancelButton.leadingAnchor, constant: -8),
+
+            cancelButton.trailingAnchor.constraint(equalTo: activeResearchView.trailingAnchor, constant: -12),
+            cancelButton.centerYAnchor.constraint(equalTo: activeResearchLabel.centerYAnchor),
+            cancelButton.widthAnchor.constraint(equalToConstant: 60),
+            cancelButton.heightAnchor.constraint(equalToConstant: 26),
+
+            progressBg.topAnchor.constraint(equalTo: activeResearchLabel.bottomAnchor, constant: 6),
+            progressBg.leadingAnchor.constraint(equalTo: activeResearchView.leadingAnchor, constant: 12),
+            progressBg.trailingAnchor.constraint(equalTo: activeResearchView.trailingAnchor, constant: -12),
+            progressBg.heightAnchor.constraint(equalToConstant: 8),
+
+            activeTimeLabel.topAnchor.constraint(equalTo: progressBg.bottomAnchor, constant: 3),
+            activeTimeLabel.centerXAnchor.constraint(equalTo: activeResearchView.centerXAnchor),
+        ])
+
         updateActiveResearchDisplay()
     }
-    
+
+    // MARK: - Tree Building
+
+    private func buildTree() {
+        // Clear old nodes and layers
+        for (_, nodeView) in nodeViews {
+            nodeView.removeFromSuperview()
+        }
+        nodeViews.removeAll()
+        lineLayer?.removeFromSuperlayer()
+        crossLineLayer?.removeFromSuperlayer()
+
+        // Remove old branch headers
+        for sub in treeContentView.subviews {
+            sub.removeFromSuperview()
+        }
+
+        let branches = ResearchBranch.allCases.filter { $0.category == selectedCategory }
+
+        var cursorY: CGFloat = treeTopPadding
+
+        for branch in branches {
+            // Branch header
+            let headerView = ResearchBranchHeaderView(branch: branch, player: player)
+            headerView.frame = CGRect(x: treeLeftPadding, y: cursorY, width: 3 * nodeWidth + 2 * tierSpacing + 10, height: branchHeaderHeight)
+            treeContentView.addSubview(headerView)
+            cursorY += branchHeaderHeight + 4
+
+            // Layout lines in this branch
+            for line in branch.researchLines {
+                for (tierIndex, research) in line.enumerated() {
+                    let x = treeLeftPadding + CGFloat(tierIndex) * (nodeWidth + tierSpacing)
+                    let nodeView = ResearchNodeView(researchType: research, player: player)
+                    nodeView.frame = CGRect(x: x, y: cursorY, width: nodeWidth, height: nodeHeight)
+                    nodeView.onTap = { [weak self] rt in
+                        self?.handleNodeTap(rt)
+                    }
+                    treeContentView.addSubview(nodeView)
+                    nodeViews[research] = nodeView
+                }
+                cursorY += nodeHeight + lineSpacing
+            }
+            cursorY += branchSpacing
+        }
+
+        let contentWidth = treeLeftPadding + 3 * nodeWidth + 2 * tierSpacing + 20
+        let contentHeight = cursorY + 20
+        treeContentView.frame = CGRect(x: 0, y: 0, width: contentWidth, height: contentHeight)
+        treeScrollView.contentSize = CGSize(width: contentWidth, height: contentHeight)
+
+        drawDependencyLines()
+    }
+
+    private func drawDependencyLines() {
+        lineLayer?.removeFromSuperlayer()
+        crossLineLayer?.removeFromSuperlayer()
+
+        let linePath = UIBezierPath()
+        let crossPath = UIBezierPath()
+
+        let branches = ResearchBranch.allCases.filter { $0.category == selectedCategory }
+
+        for branch in branches {
+            for line in branch.researchLines {
+                // Within-line connections (straight horizontal)
+                for i in 0..<(line.count - 1) {
+                    guard let fromView = nodeViews[line[i]],
+                          let toView = nodeViews[line[i + 1]] else { continue }
+                    let from = CGPoint(x: fromView.frame.maxX, y: fromView.frame.midY)
+                    let to = CGPoint(x: toView.frame.minX, y: toView.frame.midY)
+                    linePath.move(to: from)
+                    linePath.addLine(to: to)
+                }
+            }
+        }
+
+        // Cross-dependencies (curved bezier, dashed)
+        for researchType in ResearchType.allCases where researchType.category == selectedCategory {
+            guard let toView = nodeViews[researchType] else { continue }
+
+            for prereq in researchType.prerequisites {
+                guard let fromView = nodeViews[prereq] else { continue }
+
+                // Skip within-line (same row) connections - already drawn as straight lines
+                if isSameLineConnection(prereq, researchType) { continue }
+
+                let from = CGPoint(x: fromView.frame.maxX, y: fromView.frame.midY)
+                let to = CGPoint(x: toView.frame.minX, y: toView.frame.midY)
+
+                let controlX = (from.x + to.x) / 2
+                crossPath.move(to: from)
+                crossPath.addCurve(to: to,
+                                   controlPoint1: CGPoint(x: controlX, y: from.y),
+                                   controlPoint2: CGPoint(x: controlX, y: to.y))
+            }
+        }
+
+        // Solid lines for within-line
+        let solidLayer = CAShapeLayer()
+        solidLayer.path = linePath.cgPath
+        solidLayer.strokeColor = UIColor(white: 0.5, alpha: 0.7).cgColor
+        solidLayer.fillColor = UIColor.clear.cgColor
+        solidLayer.lineWidth = 1.5
+        treeContentView.layer.addSublayer(solidLayer)
+        lineLayer = solidLayer
+
+        // Dashed lines for cross-dependencies
+        let dashedLayer = CAShapeLayer()
+        dashedLayer.path = crossPath.cgPath
+        dashedLayer.strokeColor = UIColor(red: 0.9, green: 0.6, blue: 0.2, alpha: 0.7).cgColor
+        dashedLayer.fillColor = UIColor.clear.cgColor
+        dashedLayer.lineWidth = 1.5
+        dashedLayer.lineDashPattern = [4, 3]
+        treeContentView.layer.addSublayer(dashedLayer)
+        crossLineLayer = dashedLayer
+    }
+
+    private func isSameLineConnection(_ a: ResearchType, _ b: ResearchType) -> Bool {
+        // Check if a and b are adjacent in the same research line
+        let branch = b.branch
+        for line in branch.researchLines {
+            for i in 0..<(line.count - 1) {
+                if line[i] == a && line[i + 1] == b {
+                    return true
+                }
+            }
+        }
+        return false
+    }
+
     // MARK: - Update Display
-    
+
     private func updateActiveResearchDisplay() {
         let manager = ResearchManager.shared
-        
+
         if let active = manager.activeResearch {
-            let progress = active.getProgress()
-            let remaining = active.getRemainingTime()
-            
+            let speedMultiplier = manager.getResearchSpeedMultiplier()
+            let progress = active.getProgress(speedMultiplier: speedMultiplier)
+            let remaining = active.getRemainingTime(speedMultiplier: speedMultiplier)
+
             activeResearchLabel.text = "\(active.researchType.icon) \(active.researchType.displayName)"
-            
-            // Update progress bar
+
             let maxWidth = activeProgressBar.bounds.width
-            activeProgressFill.frame.size.width = maxWidth * CGFloat(progress)
-            
-            // Update time label
+            activeProgressFill.frame = CGRect(x: 0, y: 0, width: maxWidth * CGFloat(progress), height: activeProgressBar.bounds.height)
+
             let minutes = Int(remaining) / 60
             let seconds = Int(remaining) % 60
             activeTimeLabel.text = String(format: "%d:%02d remaining", minutes, seconds)
-            
+
             cancelButton.isHidden = false
         } else {
             activeResearchLabel.text = "No active research"
-            activeProgressFill.frame.size.width = 0
+            activeProgressFill.frame = CGRect(x: 0, y: 0, width: 0, height: activeProgressBar.bounds.height)
             activeTimeLabel.text = "Select research below to begin"
             cancelButton.isHidden = true
         }
     }
-    
+
+    private func updateNodeStates() {
+        for (_, nodeView) in nodeViews {
+            nodeView.updateState(player: player)
+        }
+    }
+
     // MARK: - Actions
-    
+
     @objc private func closeTapped() {
         dismiss(animated: true)
     }
-    
+
+    @objc private func segmentChanged() {
+        selectedCategory = segmentedControl.selectedSegmentIndex == 0 ? .economic : .military
+        buildTree()
+    }
+
     @objc private func cancelResearchTapped() {
         let alert = UIAlertController(
             title: "Cancel Research?",
             message: "You will receive a 50% refund of resources.",
             preferredStyle: .alert
         )
-        
+
         alert.addAction(UIAlertAction(title: "Cancel Research", style: .destructive) { [weak self] _ in
             if ResearchManager.shared.cancelResearch() {
                 self?.updateActiveResearchDisplay()
-                self?.tableView.reloadData()
+                self?.updateNodeStates()
             }
         })
-        
+
         alert.addAction(UIAlertAction(title: "Keep Researching", style: .cancel))
-        
+
         present(alert, animated: true)
     }
-    
+
+    private func handleNodeTap(_ researchType: ResearchType) {
+        let manager = ResearchManager.shared
+
+        if manager.isResearched(researchType) {
+            showAlert(title: "Already Researched",
+                      message: "\(researchType.displayName) has already been completed.\n\n\(researchType.bonusString)")
+        } else if manager.isResearching(researchType) {
+            // Do nothing, already in progress
+        } else {
+            startResearch(researchType)
+        }
+    }
+
     private func startResearch(_ researchType: ResearchType) {
         let manager = ResearchManager.shared
 
-        // Check if already researching
         if manager.activeResearch != nil {
             showAlert(title: "Already Researching", message: "Complete or cancel current research first.")
             return
         }
 
-        // Check if available (prerequisites and City Center level)
         if !manager.isAvailable(researchType) {
             if let reason = manager.getLockedReason(researchType) {
                 showAlert(title: "Locked", message: reason)
@@ -259,7 +447,6 @@ class ResearchViewController: UIViewController, UITableViewDelegate, UITableView
             return
         }
 
-        // Check resources
         if !manager.canAfford(researchType) {
             let missing = manager.getMissingResources(for: researchType)
             var message = "Missing resources:\n"
@@ -270,13 +457,11 @@ class ResearchViewController: UIViewController, UITableViewDelegate, UITableView
             return
         }
 
-        // Build confirmation message
         var confirmMessage = "\(researchType.icon) \(researchType.displayName)\n\n"
         confirmMessage += "Cost: \(researchType.costString)\n"
         confirmMessage += "Time: \(researchType.timeString)\n\n"
         confirmMessage += "Benefits:\n\(researchType.bonusString)"
 
-        // Show prerequisites if any
         if !researchType.prerequisites.isEmpty {
             confirmMessage += "\n\nPrereqs: \(researchType.prerequisitesString)"
         }
@@ -290,7 +475,7 @@ class ResearchViewController: UIViewController, UITableViewDelegate, UITableView
         alert.addAction(UIAlertAction(title: "Research", style: .default) { [weak self] _ in
             if ResearchManager.shared.startResearch(researchType) {
                 self?.updateActiveResearchDisplay()
-                self?.tableView.reloadData()
+                self?.updateNodeStates()
             }
         })
 
@@ -298,177 +483,190 @@ class ResearchViewController: UIViewController, UITableViewDelegate, UITableView
 
         present(alert, animated: true)
     }
-    
+
     private func showAlert(title: String, message: String) {
         let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
         alert.addAction(UIAlertAction(title: "OK", style: .default))
         present(alert, animated: true)
     }
-    
-    // MARK: - TableView DataSource
+}
 
-    func numberOfSections(in tableView: UITableView) -> Int {
-        return 1
+// MARK: - Research Node View
+
+class ResearchNodeView: UIView {
+
+    let researchType: ResearchType
+    var onTap: ((ResearchType) -> Void)?
+
+    private let iconLabel = UILabel()
+    private let nameLabel = UILabel()
+    private let statusIndicator = UIView()
+
+    init(researchType: ResearchType, player: Player?) {
+        self.researchType = researchType
+        super.init(frame: .zero)
+        setupUI()
+        updateState(player: player)
     }
 
-    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return researchByCategory[selectedCategory]?.count ?? 0
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
     }
 
-    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCell(withIdentifier: "ResearchCell", for: indexPath) as! ResearchCell
+    private func setupUI() {
+        layer.cornerRadius = 8
+        layer.borderWidth = 1.5
+        clipsToBounds = true
 
-        if let research = researchByCategory[selectedCategory]?[indexPath.row] {
-            cell.configure(with: research, player: player)
-        }
+        iconLabel.font = UIFont.systemFont(ofSize: 16)
+        iconLabel.textAlignment = .center
+        iconLabel.text = researchType.icon
+        addSubview(iconLabel)
 
-        return cell
+        nameLabel.font = UIFont.systemFont(ofSize: 9, weight: .semibold)
+        nameLabel.textColor = .white
+        nameLabel.numberOfLines = 2
+        nameLabel.lineBreakMode = .byTruncatingTail
+        nameLabel.text = researchType.displayName
+        addSubview(nameLabel)
+
+        statusIndicator.layer.cornerRadius = 4
+        addSubview(statusIndicator)
+
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(tapped))
+        addGestureRecognizer(tapGesture)
+        isUserInteractionEnabled = true
     }
-    
-    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        return 90
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        let h = bounds.height
+        let w = bounds.width
+        iconLabel.frame = CGRect(x: 3, y: 3, width: 22, height: 22)
+        statusIndicator.frame = CGRect(x: w - 12, y: 4, width: 8, height: 8)
+        nameLabel.frame = CGRect(x: 26, y: 3, width: w - 42, height: h - 6)
     }
-    
-    // MARK: - TableView Delegate
 
-    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        tableView.deselectRow(at: indexPath, animated: true)
+    @objc private func tapped() {
+        onTap?(researchType)
+    }
 
-        if let research = researchByCategory[selectedCategory]?[indexPath.row] {
-            let manager = ResearchManager.shared
+    func updateState(player: Player?) {
+        let manager = ResearchManager.shared
 
-            if manager.isResearched(research) {
-                showAlert(title: "Already Researched", message: "\(research.displayName) has already been completed.\n\n\(research.bonusString)")
-            } else if manager.isResearching(research) {
-                // Do nothing, already in progress
+        if manager.isResearched(researchType) {
+            // Completed: green tint
+            backgroundColor = UIColor(red: 0.15, green: 0.3, blue: 0.15, alpha: 1.0)
+            layer.borderColor = UIColor(red: 0.3, green: 0.7, blue: 0.3, alpha: 1.0).cgColor
+            statusIndicator.backgroundColor = UIColor(red: 0.3, green: 0.8, blue: 0.3, alpha: 1.0)
+            nameLabel.textColor = UIColor(white: 0.9, alpha: 1.0)
+            alpha = 0.85
+            layer.shadowColor = nil
+            layer.shadowRadius = 0
+        } else if manager.isResearching(researchType) {
+            // Researching: blue tint with glow
+            backgroundColor = UIColor(red: 0.15, green: 0.25, blue: 0.4, alpha: 1.0)
+            layer.borderColor = UIColor(red: 0.3, green: 0.6, blue: 0.9, alpha: 1.0).cgColor
+            statusIndicator.backgroundColor = UIColor(red: 0.3, green: 0.7, blue: 0.9, alpha: 1.0)
+            nameLabel.textColor = .white
+            alpha = 1.0
+            clipsToBounds = false
+            layer.shadowColor = UIColor(red: 0.3, green: 0.6, blue: 0.9, alpha: 0.6).cgColor
+            layer.shadowRadius = 6
+            layer.shadowOpacity = 0.8
+            layer.shadowOffset = .zero
+        } else if !manager.isAvailable(researchType) {
+            // Locked
+            let reason = manager.getLockedReason(researchType)
+            let isBuildingLocked = reason?.contains("Requires") == true && !(reason?.contains("City Center") == true)
+
+            if isBuildingLocked {
+                // Building gate locked: dark with distinct indicator
+                backgroundColor = UIColor(white: 0.12, alpha: 1.0)
+                layer.borderColor = UIColor(red: 0.5, green: 0.3, blue: 0.1, alpha: 0.6).cgColor
+                statusIndicator.backgroundColor = UIColor(red: 0.7, green: 0.4, blue: 0.1, alpha: 1.0)
+                nameLabel.textColor = UIColor(white: 0.4, alpha: 1.0)
+                alpha = 0.5
             } else {
-                startResearch(research)
+                // Prereq locked: dark with reduced alpha
+                backgroundColor = UIColor(white: 0.15, alpha: 1.0)
+                layer.borderColor = UIColor(white: 0.3, alpha: 0.5).cgColor
+                statusIndicator.backgroundColor = UIColor(white: 0.4, alpha: 1.0)
+                nameLabel.textColor = UIColor(white: 0.45, alpha: 1.0)
+                alpha = 0.5
             }
+            layer.shadowColor = nil
+            layer.shadowRadius = 0
+        } else if !manager.canAfford(researchType) {
+            // Available but can't afford: dimmed
+            backgroundColor = UIColor(white: 0.22, alpha: 1.0)
+            layer.borderColor = UIColor(red: 0.8, green: 0.5, blue: 0.2, alpha: 0.6).cgColor
+            statusIndicator.backgroundColor = UIColor(red: 0.9, green: 0.6, blue: 0.2, alpha: 1.0)
+            nameLabel.textColor = UIColor(white: 0.75, alpha: 1.0)
+            alpha = 0.8
+            layer.shadowColor = nil
+            layer.shadowRadius = 0
+        } else {
+            // Available: bright
+            backgroundColor = UIColor(white: 0.28, alpha: 1.0)
+            layer.borderColor = UIColor(red: 0.3, green: 0.7, blue: 0.3, alpha: 0.8).cgColor
+            statusIndicator.backgroundColor = UIColor(red: 0.3, green: 0.8, blue: 0.3, alpha: 1.0)
+            nameLabel.textColor = .white
+            alpha = 1.0
+            layer.shadowColor = nil
+            layer.shadowRadius = 0
         }
     }
 }
 
-// MARK: - Research Cell
+// MARK: - Research Branch Header View
 
-class ResearchCell: UITableViewCell {
-    
-    private let containerView = UIView()
-    private let iconLabel = UILabel()
-    private let nameLabel = UILabel()
-    private let descriptionLabel = UILabel()
-    private let costLabel = UILabel()
-    private let timeLabel = UILabel()
-    private let statusLabel = UILabel()
-    private let bonusLabel = UILabel()
-    
-    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
-        super.init(style: style, reuseIdentifier: reuseIdentifier)
-        setupUI()
+class ResearchBranchHeaderView: UIView {
+
+    init(branch: ResearchBranch, player: Player?) {
+        super.init(frame: .zero)
+        backgroundColor = UIColor(white: 0.18, alpha: 1.0)
+        layer.cornerRadius = 6
+
+        let iconLabel = UILabel()
+        iconLabel.text = branch.icon
+        iconLabel.font = UIFont.systemFont(ofSize: 16)
+        addSubview(iconLabel)
+
+        let nameLabel = UILabel()
+        nameLabel.text = branch.displayName
+        nameLabel.font = UIFont.boldSystemFont(ofSize: 13)
+        nameLabel.textColor = .white
+        addSubview(nameLabel)
+
+        let gateLabel = UILabel()
+        gateLabel.font = UIFont.systemFont(ofSize: 11, weight: .medium)
+
+        if let gate = branch.gateBuildingType {
+            // Check if player has the gate building
+            var hasGate = false
+            if let p = player {
+                hasGate = p.buildings.contains { $0.buildingType == gate && $0.isOperational }
+            }
+            if hasGate {
+                gateLabel.text = "\(gate.displayName) (built)"
+                gateLabel.textColor = UIColor(red: 0.3, green: 0.8, blue: 0.3, alpha: 1.0)
+            } else {
+                gateLabel.text = "Requires \(gate.displayName)"
+                gateLabel.textColor = UIColor(red: 0.8, green: 0.5, blue: 0.2, alpha: 1.0)
+            }
+        } else {
+            gateLabel.text = "No building required"
+            gateLabel.textColor = UIColor(white: 0.5, alpha: 1.0)
+        }
+        addSubview(gateLabel)
+
+        iconLabel.frame = CGRect(x: 8, y: 8, width: 22, height: 22)
+        nameLabel.frame = CGRect(x: 32, y: 4, width: 150, height: 18)
+        gateLabel.frame = CGRect(x: 32, y: 20, width: 250, height: 14)
     }
-    
+
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
-    }
-    
-    private func setupUI() {
-        backgroundColor = .clear
-        selectionStyle = .none
-        
-        // Container
-        containerView.backgroundColor = UIColor(white: 0.25, alpha: 1.0)
-        containerView.layer.cornerRadius = 10
-        contentView.addSubview(containerView)
-        
-        // Icon
-        iconLabel.font = UIFont.systemFont(ofSize: 28)
-        iconLabel.textAlignment = .center
-        containerView.addSubview(iconLabel)
-        
-        // Name
-        nameLabel.font = UIFont.boldSystemFont(ofSize: 16)
-        nameLabel.textColor = .white
-        containerView.addSubview(nameLabel)
-        
-        // Bonus label
-        bonusLabel.font = UIFont.systemFont(ofSize: 12, weight: .medium)
-        bonusLabel.textColor = UIColor(red: 0.5, green: 0.9, blue: 0.5, alpha: 1.0)
-        containerView.addSubview(bonusLabel)
-        
-        // Cost
-        costLabel.font = UIFont.systemFont(ofSize: 13)
-        costLabel.textColor = UIColor(white: 0.8, alpha: 1.0)
-        containerView.addSubview(costLabel)
-        
-        // Time
-        timeLabel.font = UIFont.systemFont(ofSize: 13)
-        timeLabel.textColor = UIColor(white: 0.7, alpha: 1.0)
-        containerView.addSubview(timeLabel)
-        
-        // Status
-        statusLabel.font = UIFont.boldSystemFont(ofSize: 12)
-        statusLabel.textAlignment = .right
-        containerView.addSubview(statusLabel)
-    }
-    
-    override func layoutSubviews() {
-        super.layoutSubviews()
-        
-        let padding: CGFloat = 10
-        containerView.frame = CGRect(x: 15, y: 5, width: contentView.bounds.width - 30, height: contentView.bounds.height - 10)
-        
-        iconLabel.frame = CGRect(x: padding, y: padding, width: 40, height: 40)
-        nameLabel.frame = CGRect(x: 60, y: padding, width: containerView.bounds.width - 150, height: 22)
-        bonusLabel.frame = CGRect(x: 60, y: padding + 22, width: containerView.bounds.width - 150, height: 18)
-        costLabel.frame = CGRect(x: 60, y: padding + 42, width: 150, height: 18)
-        timeLabel.frame = CGRect(x: 210, y: padding + 42, width: 100, height: 18)
-        statusLabel.frame = CGRect(x: containerView.bounds.width - 110, y: padding, width: 100, height: 25)
-    }
-    
-    func configure(with research: ResearchType, player: Player?) {
-        let manager = ResearchManager.shared
-
-        iconLabel.text = research.icon
-        nameLabel.text = "\(research.displayName) (Tier \(research.tier))"
-        bonusLabel.text = research.bonuses.map { $0.displayString }.joined(separator: ", ")
-        costLabel.text = research.costString
-        timeLabel.text = "⏱️ \(research.timeString)"
-
-        // Determine status
-        if manager.isResearched(research) {
-            statusLabel.text = "✅ Done"
-            statusLabel.textColor = UIColor(red: 0.3, green: 0.8, blue: 0.3, alpha: 1.0)
-            containerView.backgroundColor = UIColor(white: 0.2, alpha: 1.0)
-            containerView.alpha = 0.7
-        } else if manager.isResearching(research) {
-            let progress = Int((manager.activeResearch?.getProgress() ?? 0) * 100)
-            statusLabel.text = "🔬 \(progress)%"
-            statusLabel.textColor = UIColor(red: 0.3, green: 0.7, blue: 0.9, alpha: 1.0)
-            containerView.backgroundColor = UIColor(red: 0.2, green: 0.3, blue: 0.4, alpha: 1.0)
-            containerView.alpha = 1.0
-        } else if !manager.isAvailable(research) {
-            // Show specific lock reason
-            if let reason = manager.getLockedReason(research) {
-                if reason.contains("City Center") {
-                    statusLabel.text = "🏛️ CC Lv\(research.cityCenterLevelRequirement)"
-                } else {
-                    statusLabel.text = "🔒 Locked"
-                }
-            } else {
-                statusLabel.text = "🔒 Locked"
-            }
-            statusLabel.textColor = UIColor(white: 0.5, alpha: 1.0)
-            containerView.backgroundColor = UIColor(white: 0.2, alpha: 1.0)
-            containerView.alpha = 0.5
-        } else if !manager.canAfford(research) {
-            statusLabel.text = "💰 Need $"
-            statusLabel.textColor = UIColor(red: 0.9, green: 0.6, blue: 0.3, alpha: 1.0)
-            containerView.backgroundColor = UIColor(white: 0.25, alpha: 1.0)
-            containerView.alpha = 0.8
-        } else {
-            statusLabel.text = "▶️ Available"
-            statusLabel.textColor = UIColor(red: 0.3, green: 0.8, blue: 0.3, alpha: 1.0)
-            containerView.backgroundColor = UIColor(white: 0.3, alpha: 1.0)
-            containerView.alpha = 1.0
-        }
     }
 }

--- a/Grow2 iOS/ViewControllers/ResourceOverviewViewController.swift
+++ b/Grow2 iOS/ViewControllers/ResourceOverviewViewController.swift
@@ -393,7 +393,7 @@ class ResourceOverviewViewController: UIViewController {
     struct VillagerGroupGatherDetails {
         let group: VillagerGroup
         let resourcePoint: ResourcePointNode
-        let baseRate: Double              // resourceType.baseGatherRate + (villagerCount * 0.2)
+        let baseRate: Double              // villagerCount * 0.2
         let adjacencyMultiplier: Double   // 1.0 + sum of adjacency bonuses
         let researchMultiplier: Double    // from ResearchManager
         let campLevelMultiplier: Double   // building level bonus (e.g., farm Lv.2 = +10%)
@@ -502,8 +502,8 @@ class ResourceOverviewViewController: UIViewController {
         let baseGatherRatePerVillager = 0.2
         let adjacencyBonusPercent = 0.25
 
-        // Base rate = resourceType.baseGatherRate + (villagerCount * 0.2)
-        let baseRate = resourcePoint.resourceType.baseGatherRate + (Double(group.villagerCount) * baseGatherRatePerVillager)
+        // Base rate = villagerCount * 0.2
+        let baseRate = Double(group.villagerCount) * baseGatherRatePerVillager
 
         // Calculate adjacency bonus for the resource point
         let (adjacencyMultiplier, adjacencySources) = calculateResourcePointAdjacency(

--- a/Grow2 iOS/ViewControllers/TrainingOverViewController.swift
+++ b/Grow2 iOS/ViewControllers/TrainingOverViewController.swift
@@ -184,10 +184,11 @@ class TrainingBuildingCell: UITableViewCell {
 
     // MARK: - Time Calculation Helpers
 
-    func getRemainingTime(for entry: TrainingQueueEntryData, currentTime: TimeInterval) -> TimeInterval {
+    func getRemainingTime(for entry: TrainingQueueEntryData, currentTime: TimeInterval, trainingSpeedMultiplier: Double = 1.0) -> TimeInterval {
         let baseTime = entry.unitType.trainingTime * Double(entry.quantity)
+        let totalTime = baseTime / trainingSpeedMultiplier
         let elapsed = currentTime - entry.startTime
-        return max(0, baseTime - elapsed)
+        return max(0, totalTime - elapsed)
     }
 
     func getRemainingTime(for entry: VillagerTrainingEntryData, currentTime: TimeInterval) -> TimeInterval {
@@ -204,8 +205,11 @@ class TrainingBuildingCell: UITableViewCell {
 
     func calculateTotalRemaining(_ building: BuildingNode, currentTime: TimeInterval) -> TimeInterval {
         var total: TimeInterval = 0
+        let researchMultiplier = ResearchManager.shared.getMilitaryTrainingSpeedMultiplier()
+        let buildingMultiplier = building.data.getTrainingSpeedMultiplier()
+        let combinedMultiplier = researchMultiplier * buildingMultiplier
         for entry in building.trainingQueue {
-            total += getRemainingTime(for: entry, currentTime: currentTime)
+            total += getRemainingTime(for: entry, currentTime: currentTime, trainingSpeedMultiplier: combinedMultiplier)
         }
         for entry in building.villagerTrainingQueue {
             total += getRemainingTime(for: entry, currentTime: currentTime)
@@ -303,9 +307,12 @@ class TrainingBuildingCell: UITableViewCell {
         let currentTime = Date().timeIntervalSince1970
 
         // Process military queue
+        let researchMultiplier = ResearchManager.shared.getMilitaryTrainingSpeedMultiplier()
+        let buildingMultiplier = building.data.getTrainingSpeedMultiplier()
+        let combinedMultiplier = researchMultiplier * buildingMultiplier
         for (index, entry) in building.trainingQueue.enumerated() {
-            let progress = entry.getProgress(currentTime: currentTime)
-            let remaining = getRemainingTime(for: entry, currentTime: currentTime)
+            let progress = entry.getProgress(currentTime: currentTime, trainingSpeedMultiplier: combinedMultiplier)
+            let remaining = getRemainingTime(for: entry, currentTime: currentTime, trainingSpeedMultiplier: combinedMultiplier)
             addQueueItemView(
                 index: index + 1,
                 icon: entry.unitType.icon,

--- a/Grow2.xcodeproj/project.pbxproj
+++ b/Grow2.xcodeproj/project.pbxproj
@@ -106,6 +106,7 @@
 		3FBDVC0001000000000GARRI /* BuildingDetailViewController+Garrison.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FBDVC0002000000000GARRI /* BuildingDetailViewController+Garrison.swift */; };
 		3FBDVC0001000000000UPGRD /* BuildingDetailViewController+Upgrades.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FBDVC0002000000000UPGRD /* BuildingDetailViewController+Upgrades.swift */; };
 		3FBDVC0001000000000UUPUI /* BuildingDetailViewController+UnitUpgrades.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FBDVC0002000000000UUPUI /* BuildingDetailViewController+UnitUpgrades.swift */; };
+		3FBDVC0001000000000HMBSE /* BuildingDetailViewController+HomeBase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FBDVC0002000000000HMBSE /* BuildingDetailViewController+HomeBase.swift */; };
 		3FGSCN0001000000000INPTH /* GameScene+InputHandling.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FGSCN0002000000000INPTH /* GameScene+InputHandling.swift */; };
 		3FF8CF5B2F0D92CE002FA5D7 /* VillagerMergeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FF8CF5A2F0D92CE002FA5D7 /* VillagerMergeViewController.swift */; };
 		3FF8CF5D2F0DA5CC002FA5D7 /* AlertHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FF8CF5C2F0DA5CC002FA5D7 /* AlertHelper.swift */; };
@@ -248,6 +249,7 @@
 		3FBDVC0002000000000GARRI /* BuildingDetailViewController+Garrison.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BuildingDetailViewController+Garrison.swift"; sourceTree = "<group>"; };
 		3FBDVC0002000000000UPGRD /* BuildingDetailViewController+Upgrades.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BuildingDetailViewController+Upgrades.swift"; sourceTree = "<group>"; };
 		3FBDVC0002000000000UUPUI /* BuildingDetailViewController+UnitUpgrades.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BuildingDetailViewController+UnitUpgrades.swift"; sourceTree = "<group>"; };
+		3FBDVC0002000000000HMBSE /* BuildingDetailViewController+HomeBase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BuildingDetailViewController+HomeBase.swift"; sourceTree = "<group>"; };
 		3FGSCN0002000000000INPTH /* GameScene+InputHandling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GameScene+InputHandling.swift"; sourceTree = "<group>"; };
 		3FF8CF5A2F0D92CE002FA5D7 /* VillagerMergeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VillagerMergeViewController.swift; sourceTree = "<group>"; };
 		3FF8CF5C2F0DA5CC002FA5D7 /* AlertHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertHelper.swift; sourceTree = "<group>"; };
@@ -442,6 +444,7 @@
 				3FBDVC0002000000000TRAIN /* BuildingDetailViewController+Training.swift */,
 				3FBDVC0002000000000UPGRD /* BuildingDetailViewController+Upgrades.swift */,
 				3FBDVC0002000000000UUPUI /* BuildingDetailViewController+UnitUpgrades.swift */,
+				3FBDVC0002000000000HMBSE /* BuildingDetailViewController+HomeBase.swift */,
 				3F39A62D2F14728500E9F506 /* BuildingsOverviewViewController.swift */,
 				3FEBD2042EF3628400341AEE /* CombatHistoryViewController.swift */,
 				3FCMBTDTL22F28C00100CMBTD /* CombatDetailViewController.swift */,
@@ -721,6 +724,7 @@
 				3FBDVC0001000000000GARRI /* BuildingDetailViewController+Garrison.swift in Sources */,
 				3FBDVC0001000000000UPGRD /* BuildingDetailViewController+Upgrades.swift in Sources */,
 				3FBDVC0001000000000UUPUI /* BuildingDetailViewController+UnitUpgrades.swift in Sources */,
+				3FBDVC0001000000000HMBSE /* BuildingDetailViewController+HomeBase.swift in Sources */,
 				3FGSCN0001000000000INPTH /* GameScene+InputHandling.swift in Sources */,
 				3FC0F1002EC7965F007C0782 /* AppDelegate.swift in Sources */,
 				3FAB1B4C2F1AAE37004775C1 /* RecruitCommanderCommand.swift in Sources */,

--- a/README.md
+++ b/README.md
@@ -27,14 +27,15 @@ Mobile strategy games have incredible potential: massive maps, diplomacy, resour
 16 building types across economic and military categories:
 
 **Economic Buildings**
-- **City Center** — Main hub for economy and population (upgradeable to level 10)
-- **Farm** — Produces food resources with gathering bonuses
-- **Neighborhood** — Houses population
+- **City Center** — Main hub for economy and population (upgradeable to level 10, population scales with level: 10/15/20/.../55)
+- **Farm** — Produces food resources with gathering bonuses (+10% per level above 1)
+- **Neighborhood** — Houses population (capacity scales with level: 5/8/11/14/17)
 - **Warehouse** — Stores extra resources
 - **Market** — Trade resources
-- **Lumber Camp** — Increases wood collection (+1.5x bonus)
-- **Mining Camp** — Increases ore collection (+1.5x bonus)
+- **Lumber Camp** — Increases wood collection (+1.5x bonus, +10% per level above 1)
+- **Mining Camp** — Increases ore collection (+1.5x bonus, +10% per level above 1)
 - **Blacksmith** — Upgrades units and tools
+- **Library** — Boosts research speed (+10% per level) and unlocks advanced research branches
 - **University** — Research technologies
 
 **Military Buildings**
@@ -46,7 +47,11 @@ Mobile strategy games have incredible potential: massive maps, diplomacy, resour
 - **Tower** — Defensive structure
 - **Wooden Fort** — Basic defensive fortification
 
-Buildings unlock progressively based on City Center level, creating meaningful tech tree decisions.
+Buildings unlock progressively based on City Center level, creating meaningful tech tree decisions. Military buildings grant +10% training speed per building level above 1.
+
+**Terrain Effects on Building:**
+- Mountain tiles apply a +25% cost multiplier to construction and upgrades
+- Cost adjustments are shown in the build/upgrade UI and properly refunded on cancellation
 
 ### ⚔️ Military Units & Commanders
 - **Entity-based system** — Armies and Villager Groups instead of individual unit micromanagement
@@ -102,8 +107,10 @@ Resources can be gathered from map deposits (with depletion mechanics) or produc
 #### Siege (Siege Workshop)
 | Unit | HP | Move Speed | Attack Speed | Training Time | Cost |
 |------|-----|------------|--------------|---------------|------|
-| Mangonel | 70 | 2.00s/tile | 2.5s | 45s | 60 Food, 100 Wood, 40 Ore |
-| Trebuchet | 120 | 2.40s/tile | 4.0s | 60s | 80 Food, 150 Wood, 60 Ore |
+| Mangonel | 70 | 2.00s/tile | 2.5s | 45s | 60 Food, 100 Wood, 40 Ore | 3 pop |
+| Trebuchet | 120 | 2.40s/tile | 4.0s | 60s | 80 Food, 150 Wood, 60 Ore | 5 pop |
+
+Siege units cost more population space than standard units (mangonels: 3, trebuchets: 5 vs 1 for all other units). Pop space is accounted for across army composition, garrisons, training queues, food consumption, and training UI slider limits.
 
 #### Combat Stats
 
@@ -184,48 +191,94 @@ Bonuses stack if multiple source buildings are adjacent.
 
 ### 🔬 Research System
 
-75 total technologies across Economic (30) and Military (45) research lines.
+75 total technologies organized into 7 branches with cross-branch dependencies and building gates.
 
 #### Tier Requirements
 - **Tier I:** City Center Level 1 (30 sec research time)
 - **Tier II:** City Center Level 2 (60 sec research time)
 - **Tier III:** City Center Level 3 (120 sec research time)
 
-#### Economic Research (10 Lines × 3 Tiers = 30 Technologies)
+#### Branch-Based Building Gates
+- **Gathering & Logistics:** No gate building required
+- **Commerce:** Requires Library (Tier II+)
+- **Infrastructure:** Requires University (Tier II+)
+- **Melee/Ranged/Siege Equipment:** Requires Blacksmith (Tier II+)
 
+Research speed is boosted by +10% per Library level.
+
+#### Research Branches
+
+**Gathering** (Economic)
 | Research Line | Tier I | Tier II | Tier III | Bonus Type |
 |---------------|--------|---------|----------|------------|
 | Farm Efficiency | +10% | +15% | +20% | Farm gather rate |
 | Mining Efficiency | +10% | +15% | +20% | Mining Camp gather rate |
 | Lumber Efficiency | +10% | +15% | +20% | Lumber Camp gather rate |
+
+**Commerce** (Economic — requires Library)
+| Research Line | Tier I | Tier II | Tier III | Bonus Type |
+|---------------|--------|---------|----------|------------|
 | Better Market Rates | +5% | +10% | +15% | Market exchange rates |
-| Swift Villagers | +10% | +15% | +20% | Villager movement speed |
 | Trade Routes | +10% | +15% | +20% | Trade speed |
+| Efficient Rations | -5% | -10% | -15% | Food consumption |
+
+**Infrastructure** (Economic — requires University)
+| Research Line | Tier I | Tier II | Tier III | Bonus Type |
+|---------------|--------|---------|----------|------------|
 | Improved Roads | +10% | +15% | +20% | Road speed bonus |
 | Urban Planning | +5 | +10 | +15 | Population capacity (flat) |
-| Efficient Rations | -5% | -10% | -15% | Food consumption |
 | Construction | +10% | +15% | +20% | Building speed |
+| Fortifications | +10% | +15% | +20% | Building HP |
 
-#### Military Research (15 Lines × 3 Tiers = 45 Technologies)
-
+**Logistics** (Military)
 | Research Line | Tier I | Tier II | Tier III | Bonus Type |
 |---------------|--------|---------|----------|------------|
 | Forced March | +5% | +7% | +10% | Army movement speed |
 | Tactical Retreat | +5% | +7% | +10% | Retreat speed |
+| Swift Villagers | +10% | +15% | +20% | Villager movement speed |
+| Military Drills | +10% | +15% | +20% | Military training speed |
+| Field Rations | -5% | -10% | -15% | Military food consumption |
+
+**Melee Equipment** (Military — requires Blacksmith)
+| Research Line | Tier I | Tier II | Tier III | Bonus Type |
+|---------------|--------|---------|----------|------------|
 | Infantry Weapons | +5% | +7% | +10% | Infantry melee attack |
 | Cavalry Weapons | +5% | +7% | +10% | Cavalry melee attack |
 | Infantry Shields | +5% | +7% | +10% | Infantry melee armor |
 | Cavalry Barding | +5% | +7% | +10% | Cavalry melee armor |
-| Archer Padding | +5% | +7% | +10% | Archer melee armor |
+
+**Ranged Equipment** (Military — requires Blacksmith)
+| Research Line | Tier I | Tier II | Tier III | Bonus Type |
+|---------------|--------|---------|----------|------------|
 | Bodkin Points | +5% | +7% | +10% | Pierce damage |
+| Archer Padding | +5% | +7% | +10% | Archer melee armor |
 | Infantry Mail | +5% | +7% | +10% | Infantry pierce armor |
 | Cavalry Mail | +5% | +7% | +10% | Cavalry pierce armor |
 | Archer Mail | +5% | +7% | +10% | Archer pierce armor |
+
+**Siege & Fortification** (Military — requires Blacksmith)
+| Research Line | Tier I | Tier II | Tier III | Bonus Type |
+|---------------|--------|---------|----------|------------|
 | Siege Ammunition | +5% | +7% | +10% | Siege bludgeon damage |
 | Reinforced Walls | +5% | +7% | +10% | Building bludgeon armor |
-| Military Drills | +10% | +15% | +20% | Military training speed |
-| Field Rations | -5% | -10% | -15% | Military food consumption |
-| Fortifications | +10% | +15% | +20% | Building HP |
+
+13 cross-branch dependencies connect the tree (e.g., Lumber Efficiency II requires Construction I). The research tree UI displays branches with color-coded nodes and dependency lines (solid within-branch, dashed orange for cross-branch).
+
+### 🏗️ Construction System
+
+Construction uses an **incremental HP accumulation** model with diminishing builder returns. Multiple villagers can work on a building, but each additional builder contributes less (0.8x diminishing factor). This makes initial builders highly valuable while limiting the benefit of over-stacking.
+
+### 🏠 Army Home Base Capacity
+
+Armies require a home base (Castle or Wooden Fort) with available capacity:
+
+| Building | Base Capacity | Per Level | Example (Level 3) |
+|----------|--------------|-----------|-------------------|
+| Castle | 3 armies | +1/level | 5 armies |
+| Wooden Fort | 1 army | +1/level | 3 armies |
+
+- Deployment checks base capacity before assigning; falls back to nearest base with room
+- Retreat logic uses capacity-aware base finding
 
 ### 🏔️ Terrain Bonuses
 
@@ -414,12 +467,12 @@ Grow2/
 
 **✅ Implemented**
 - Hex map generation and rendering
-- Complete building system with construction progress
-- Resource gathering with villager capacity and depletion
-- Military training queues with slider-based quantity selection
+- Complete building system with construction progress and diminishing builder returns
+- Resource gathering with villager capacity, depletion, and camp level bonuses
+- Military training queues with slider-based quantity selection and building level speed bonuses
 - Commander system with 5 stats, 10 specialties, leveling, and rank progression
 - Fog of war with diplomatic vision sharing
-- Research system with background timers
+- Branch-based research tree (7 branches, building gates, cross-dependencies, Library speed bonus)
 - Save/load with offline progress calculation
 - Entity-based army and villager management
 - Command pattern architecture
@@ -428,10 +481,14 @@ Grow2/
 - Multi-army stack combat with tiered defensive engagement
 - Unit upgrade system (3 tiers per unit type)
 - Notification system with priority-based toast banners
+- Mountain terrain +25% building cost multiplier
+- Siege unit pop space (mangonels: 3, trebuchets: 5)
+- Scaling population capacity (Neighborhood and City Center scale with level)
+- Army home base capacity system (Castle/Fort with per-level scaling)
+- Next-level benefits preview in building upgrade UI
 
 **🚧 In Development**
 - Balance tuning and playtesting
-- Additional research items
 - UI/UX refinements
 
 ---


### PR DESCRIPTION
## Summary
- **Road-connected gathering fix**: `ResourceEngine.hasCampCoverage` now uses BFS through buildings/roads, matching the visual layer's `HexMap.getExtendedCampReach()`. Road-connected resources correctly register with the engine at full gather rate.
- **Removed base gather rate**: Gathering rate now scales purely with villager count (0.2/sec/villager × multipliers) instead of adding a flat 0.5/sec base regardless of villagers.
- **Building detail UI**: Added cost display on build menu, demolish refund amounts, next-level benefits on upgrade section, training speed bonuses, home base capacity display.
- **Research tree redesign**: Branch-based layout with building gates (Library→commerce, University→infrastructure, Blacksmith→equipment) and cross-dependency lines.
- **Balance**: Neighborhood/City Center population scales with level, siege units cost population space (mangonels 3, trebuchets 5), camp level gathering bonuses, construction HP model, mountain tile building cost multipliers.

## Issues

Closes #3, closes #4, closes #6, closes #7, closes #8, closes #17, closes #18, closes #19, closes #20, closes #22, closes #23, closes #24, closes #25, closes #26

## Test plan
- [ ] Build a lumber camp, gather adjacent trees → verify rate matches villager count × 0.2/sec × multipliers
- [ ] Build road to distant trees, gather → verify same rate as adjacent (was lower before fix)
- [ ] Stop gathering → rate drops to 0
- [ ] Verify building detail UI shows costs, refund amounts, upgrade previews
- [ ] Verify research tree displays correctly with branch layout and dependency lines
- [ ] Verify neighborhood/city center population scales with building level

🤖 Generated with [Claude Code](https://claude.com/claude-code)